### PR TITLE
Remove onresize handler on detached

### DIFF
--- a/src/virtual-repeat.js
+++ b/src/virtual-repeat.js
@@ -91,6 +91,9 @@ export class VirtualRepeat {
   }
 
   detached() {
+    // TODO Fix this
+    window.onresize = null;
+
     this.scrollContainer.removeEventListener('scroll', this.scrollListener);
     this._first = 0;
     this._previousFirst = 0;


### PR DESCRIPTION
The onresize handler is generating errors if the virtual-repeat control is remove from the page.
