### PR TITLE
fix(utilities): undefined parentElement in IE11

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -12,7 +12,13 @@ export function insertBeforeNode(view: View, bottomBuffer: number): void {
   let viewStart = view.firstChild;
   let element = viewStart.nextSibling;
   let viewEnd = view.lastChild;
-  let parentElement = bottomBuffer.parentElement;
+  let parentElement;
+
+  if (bottomBuffer.parentElement) {
+    parentElement = bottomBuffer.parentElement;
+  } else if (bottomBuffer.parentNode) {
+    parentElement = bottomBuffer.parentNode;
+  }
 
   parentElement.insertBefore(viewEnd, bottomBuffer);
   parentElement.insertBefore(element, viewEnd);


### PR DESCRIPTION
Property 'parentElement' is undefined in IE11 and lower causing the plugin to break in these browsers. 
