### PR TITLE
perf(array-virtual-repeat-strategy): optimise case where mutations do…

### DIFF
--- a/config.js
+++ b/config.js
@@ -14,162 +14,181 @@ System.config({
   },
 
   map: {
-    "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.3.2",
-    "aurelia-bootstrapper": "npm:aurelia-bootstrapper@1.0.0-beta.1.2.0",
-    "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.0",
-    "aurelia-framework": "npm:aurelia-framework@1.0.0-beta.1.2.2",
-    "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0",
-    "aurelia-logging-console": "npm:aurelia-logging-console@1.0.0-beta.1.2.0",
-    "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0",
-    "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.2.0",
-    "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.1",
-    "aurelia-polyfills": "npm:aurelia-polyfills@1.0.0-beta.1.1.2",
-    "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.2.0",
-    "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.2.2",
-    "aurelia-templating-resources": "npm:aurelia-templating-resources@1.0.0-beta.1.2.2",
+    "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.3.6",
+    "aurelia-bootstrapper": "npm:aurelia-bootstrapper@1.0.0-beta.1.2.1",
+    "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.3",
+    "aurelia-framework": "npm:aurelia-framework@1.0.0-beta.1.2.5",
+    "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.1",
+    "aurelia-logging-console": "npm:aurelia-logging-console@1.0.0-beta.1.2.1",
+    "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2",
+    "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.2.1",
+    "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.2",
+    "aurelia-polyfills": "npm:aurelia-polyfills@1.0.0-beta.1.1.4",
+    "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.2.1",
+    "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.2.7",
+    "aurelia-templating-resources": "npm:aurelia-templating-resources@1.0.0-beta.1.2.6",
     "babel": "npm:babel-core@5.8.38",
     "babel-runtime": "npm:babel-runtime@5.8.38",
     "core-js": "npm:core-js@1.2.6",
     "traceur": "github:jmcriffey/bower-traceur@0.0.92",
     "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.92",
     "github:jspm/nodelibs-assert@0.1.0": {
-      "assert": "npm:assert@1.3.0"
+      "assert": "npm:assert@1.4.0"
+    },
+    "github:jspm/nodelibs-buffer@0.1.0": {
+      "buffer": "npm:buffer@3.6.0"
     },
     "github:jspm/nodelibs-path@0.1.0": {
       "path-browserify": "npm:path-browserify@0.0.0"
     },
     "github:jspm/nodelibs-process@0.1.2": {
-      "process": "npm:process@0.11.2"
+      "process": "npm:process@0.11.3"
     },
     "github:jspm/nodelibs-util@0.1.0": {
       "util": "npm:util@0.10.3"
     },
-    "npm:assert@1.3.0": {
+    "npm:assert@1.4.0": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer-shims": "npm:buffer-shims@1.0.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
       "util": "npm:util@0.10.3"
     },
-    "npm:aurelia-binding@1.0.0-beta.1.3.2": {
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.2.0"
+    "npm:aurelia-binding@1.0.0-beta.1.3.6": {
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.1",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.2.1"
     },
-    "npm:aurelia-bootstrapper@1.0.0-beta.1.2.0": {
-      "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.0-beta.1.2.0",
-      "aurelia-framework": "npm:aurelia-framework@1.0.0-beta.1.2.2",
-      "aurelia-history": "npm:aurelia-history@1.0.0-beta.1.2.0",
-      "aurelia-history-browser": "npm:aurelia-history-browser@1.0.0-beta.1.2.0",
-      "aurelia-loader-default": "npm:aurelia-loader-default@1.0.0-beta.1.2.1",
-      "aurelia-logging-console": "npm:aurelia-logging-console@1.0.0-beta.1.2.0",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0",
-      "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.2.0",
-      "aurelia-polyfills": "npm:aurelia-polyfills@1.0.0-beta.1.1.2",
-      "aurelia-router": "npm:aurelia-router@1.0.0-beta.1.2.1",
-      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.2.2",
-      "aurelia-templating-binding": "npm:aurelia-templating-binding@1.0.0-beta.1.2.1",
-      "aurelia-templating-resources": "npm:aurelia-templating-resources@1.0.0-beta.1.2.2",
-      "aurelia-templating-router": "npm:aurelia-templating-router@1.0.0-beta.1.2.0"
+    "npm:aurelia-bootstrapper@1.0.0-beta.1.2.1": {
+      "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.0-beta.1.2.1",
+      "aurelia-framework": "npm:aurelia-framework@1.0.0-beta.1.2.5",
+      "aurelia-history": "npm:aurelia-history@1.0.0-beta.1.2.1",
+      "aurelia-history-browser": "npm:aurelia-history-browser@1.0.0-beta.1.2.1",
+      "aurelia-loader-default": "npm:aurelia-loader-default@1.0.0-beta.1.2.2",
+      "aurelia-logging-console": "npm:aurelia-logging-console@1.0.0-beta.1.2.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2",
+      "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.2.1",
+      "aurelia-polyfills": "npm:aurelia-polyfills@1.0.0-beta.1.1.4",
+      "aurelia-router": "npm:aurelia-router@1.0.0-beta.1.2.3",
+      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.2.7",
+      "aurelia-templating-binding": "npm:aurelia-templating-binding@1.0.0-beta.1.2.4",
+      "aurelia-templating-resources": "npm:aurelia-templating-resources@1.0.0-beta.1.2.6",
+      "aurelia-templating-router": "npm:aurelia-templating-router@1.0.0-beta.1.2.1"
     },
-    "npm:aurelia-dependency-injection@1.0.0-beta.1.2.0": {
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
+    "npm:aurelia-dependency-injection@1.0.0-beta.1.2.3": {
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.1",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2"
     },
-    "npm:aurelia-event-aggregator@1.0.0-beta.1.2.0": {
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0"
+    "npm:aurelia-event-aggregator@1.0.0-beta.1.2.1": {
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.1"
     },
-    "npm:aurelia-framework@1.0.0-beta.1.2.2": {
-      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.3.2",
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.0",
+    "npm:aurelia-framework@1.0.0-beta.1.2.5": {
+      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.3.6",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.3",
       "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.2.0",
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0",
-      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.1",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.2.0",
-      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.2.2"
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.1",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.2",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.2.1",
+      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.2.7"
     },
-    "npm:aurelia-history-browser@1.0.0-beta.1.2.0": {
-      "aurelia-history": "npm:aurelia-history@1.0.0-beta.1.2.0",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
+    "npm:aurelia-history-browser@1.0.0-beta.1.2.1": {
+      "aurelia-history": "npm:aurelia-history@1.0.0-beta.1.2.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2"
     },
-    "npm:aurelia-loader-default@1.0.0-beta.1.2.1": {
+    "npm:aurelia-loader-default@1.0.0-beta.1.2.2": {
       "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.2.0",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2"
     },
     "npm:aurelia-loader@1.0.0-beta.1.2.0": {
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
-      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.1"
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.1",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.2"
     },
-    "npm:aurelia-logging-console@1.0.0-beta.1.2.0": {
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
+    "npm:aurelia-logging-console@1.0.0-beta.1.2.1": {
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2"
     },
-    "npm:aurelia-metadata@1.0.0-beta.1.2.0": {
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
+    "npm:aurelia-metadata@1.0.0-beta.1.2.1": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2"
     },
-    "npm:aurelia-pal-browser@1.0.0-beta.1.2.0": {
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
+    "npm:aurelia-pal-browser@1.0.0-beta.1.2.1": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2"
     },
-    "npm:aurelia-polyfills@1.0.0-beta.1.1.2": {
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
+    "npm:aurelia-polyfills@1.0.0-beta.1.1.4": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2"
     },
-    "npm:aurelia-route-recognizer@1.0.0-beta.1.2.0": {
-      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.1"
+    "npm:aurelia-route-recognizer@1.0.0-beta.1.2.1": {
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.2"
     },
-    "npm:aurelia-router@1.0.0-beta.1.2.1": {
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.0",
-      "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.0-beta.1.2.0",
-      "aurelia-history": "npm:aurelia-history@1.0.0-beta.1.2.0",
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0",
-      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.1",
-      "aurelia-route-recognizer": "npm:aurelia-route-recognizer@1.0.0-beta.1.2.0"
+    "npm:aurelia-router@1.0.0-beta.1.2.3": {
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.3",
+      "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.0-beta.1.2.1",
+      "aurelia-history": "npm:aurelia-history@1.0.0-beta.1.2.1",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.1",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.2",
+      "aurelia-route-recognizer": "npm:aurelia-route-recognizer@1.0.0-beta.1.2.1"
     },
-    "npm:aurelia-task-queue@1.0.0-beta.1.2.0": {
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
+    "npm:aurelia-task-queue@1.0.0-beta.1.2.1": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2"
     },
-    "npm:aurelia-templating-binding@1.0.0-beta.1.2.1": {
-      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.3.2",
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0",
-      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.2.2"
+    "npm:aurelia-templating-binding@1.0.0-beta.1.2.4": {
+      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.3.6",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.1",
+      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.2.7"
     },
-    "npm:aurelia-templating-resources@1.0.0-beta.1.2.2": {
-      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.3.2",
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.0",
+    "npm:aurelia-templating-resources@1.0.0-beta.1.2.6": {
+      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.3.6",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.3",
       "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.2.0",
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0",
-      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.1",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.2.0",
-      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.2.2"
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.1",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.2",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.2.1",
+      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.2.7"
     },
-    "npm:aurelia-templating-router@1.0.0-beta.1.2.0": {
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.0",
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0",
-      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.1",
-      "aurelia-router": "npm:aurelia-router@1.0.0-beta.1.2.1",
-      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.2.2"
+    "npm:aurelia-templating-router@1.0.0-beta.1.2.1": {
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.3",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.1",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.2",
+      "aurelia-router": "npm:aurelia-router@1.0.0-beta.1.2.3",
+      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1.2.7"
     },
-    "npm:aurelia-templating@1.0.0-beta.1.2.2": {
-      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.3.2",
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.0",
+    "npm:aurelia-templating@1.0.0-beta.1.2.7": {
+      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.3.6",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.3",
       "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.2.0",
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
-      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0",
-      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.1",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.2.0"
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.1",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.2",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1.2.1"
     },
     "npm:babel-runtime@5.8.38": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:buffer-shims@1.0.0": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0"
+    },
+    "npm:buffer@3.6.0": {
+      "base64-js": "npm:base64-js@0.0.8",
+      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "ieee754": "npm:ieee754@1.1.6",
+      "isarray": "npm:isarray@1.0.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:core-js@1.2.6": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:inherits@2.0.1": {
       "util": "github:jspm/nodelibs-util@0.1.0"
@@ -177,7 +196,7 @@ System.config({
     "npm:path-browserify@0.0.0": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:process@0.11.2": {
+    "npm:process@0.11.3": {
       "assert": "github:jspm/nodelibs-assert@0.1.0"
     },
     "npm:util@0.10.3": {

--- a/dist/amd/array-virtual-repeat-strategy.js
+++ b/dist/amd/array-virtual-repeat-strategy.js
@@ -139,30 +139,47 @@ define(['exports', 'aurelia-templating-resources', './utilities'], function (exp
     ArrayVirtualRepeatStrategy.prototype._runSplices = function _runSplices(repeat, array, splices) {
       var _this3 = this;
 
-      var removeDelta = 0;
-      var rmPromises = [];
+      var allSplicesAreInplace = splices.reduce(function (prev, splice) {
+        return prev && splice.removed.length === splice.addedCount;
+      }, true);
 
-      for (var i = 0, ii = splices.length; i < ii; ++i) {
-        var splice = splices[i];
-        var removed = splice.removed;
-        var removedLength = removed.length;
-        for (var j = 0, jj = removedLength; j < jj; ++j) {
-          var viewOrPromise = this._removeViewAt(repeat, splice.index + removeDelta + rmPromises.length, true, j, removedLength);
-          if (viewOrPromise instanceof Promise) {
-            rmPromises.push(viewOrPromise);
+      if (allSplicesAreInplace) {
+        splices.forEach(function (splice) {
+          for (var collectionIndex = splice.index; collectionIndex < splice.index + splice.addedCount; collectionIndex++) {
+            if (!_this3._isIndexBeforeViewSlot(repeat, repeat.viewSlot, collectionIndex) && !_this3._isIndexAfterViewSlot(repeat, repeat.viewSlot, collectionIndex)) {
+              var viewIndex = _this3._getViewIndex(repeat, repeat.viewSlot, collectionIndex);
+              var overrideContext = (0, _aureliaTemplatingResources.createFullOverrideContext)(repeat, array[collectionIndex], collectionIndex, array.length);
+              repeat.removeView(viewIndex, true, true);
+              repeat.insertView(viewIndex, overrideContext.bindingContext, overrideContext);
+            }
           }
-        }
-        removeDelta -= splice.addedCount;
-      }
-
-      if (rmPromises.length > 0) {
-        return Promise.all(rmPromises).then(function () {
-          _this3._handleAddedSplices(repeat, array, splices);
-          (0, _utilities.updateVirtualOverrideContexts)(repeat, 0);
         });
+      } else {
+        var removeDelta = 0;
+        var rmPromises = [];
+
+        for (var i = 0, ii = splices.length; i < ii; ++i) {
+          var splice = splices[i];
+          var removed = splice.removed;
+          var removedLength = removed.length;
+          for (var j = 0, jj = removedLength; j < jj; ++j) {
+            var viewOrPromise = this._removeViewAt(repeat, splice.index + removeDelta + rmPromises.length, true, j, removedLength);
+            if (viewOrPromise instanceof Promise) {
+              rmPromises.push(viewOrPromise);
+            }
+          }
+          removeDelta -= splice.addedCount;
+        }
+
+        if (rmPromises.length > 0) {
+          return Promise.all(rmPromises).then(function () {
+            _this3._handleAddedSplices(repeat, array, splices);
+            (0, _utilities.updateVirtualOverrideContexts)(repeat, 0);
+          });
+        }
+        this._handleAddedSplices(repeat, array, splices);
+        (0, _utilities.updateVirtualOverrideContexts)(repeat, 0);
       }
-      this._handleAddedSplices(repeat, array, splices);
-      (0, _utilities.updateVirtualOverrideContexts)(repeat, 0);
     };
 
     ArrayVirtualRepeatStrategy.prototype._removeViewAt = function _removeViewAt(repeat, collectionIndex, returnToCache, j, removedLength) {

--- a/dist/aurelia-ui-virtualization.js
+++ b/dist/aurelia-ui-virtualization.js
@@ -195,30 +195,51 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy {
   }
 
   _runSplices(repeat: VirtualRepeat, array: Array, splices: any): any {
-    let removeDelta = 0;
-    let rmPromises = [];
 
-    for (let i = 0, ii = splices.length; i < ii; ++i) {
-      let splice = splices[i];
-      let removed = splice.removed;
-      let removedLength = removed.length;
-      for (let j = 0, jj = removedLength; j < jj; ++j) {
-        let viewOrPromise = this._removeViewAt(repeat, splice.index + removeDelta + rmPromises.length, true, j, removedLength);
-        if (viewOrPromise instanceof Promise) {
-          rmPromises.push(viewOrPromise);
+    // do all splices replace existing entries?
+    let allSplicesAreInplace = splices.reduce( (prev,splice) => { 
+      return prev && splice.removed.length===splice.addedCount; 
+    }, true);
+
+    // if so, optimise by just replacing affected visible views
+    if( allSplicesAreInplace ) {
+      splices.forEach( (splice) => {
+        for ( let collectionIndex = splice.index; collectionIndex<splice.index+splice.addedCount; collectionIndex++ ) {
+          if( !this._isIndexBeforeViewSlot(repeat, repeat.viewSlot, collectionIndex) && !this._isIndexAfterViewSlot(repeat, repeat.viewSlot, collectionIndex) ) {
+            let viewIndex = this._getViewIndex(repeat, repeat.viewSlot, collectionIndex);
+            let overrideContext = createFullOverrideContext(repeat, array[collectionIndex], collectionIndex, array.length);
+            repeat.removeView(viewIndex, true, true);            
+            repeat.insertView(viewIndex, overrideContext.bindingContext, overrideContext);
+          }
         }
-      }
-      removeDelta -= splice.addedCount;
-    }
-
-    if (rmPromises.length > 0) {
-      return Promise.all(rmPromises).then(() => {
-        this._handleAddedSplices(repeat, array, splices);
-        updateVirtualOverrideContexts(repeat, 0);
       });
     }
-    this._handleAddedSplices(repeat, array, splices);
-    updateVirtualOverrideContexts(repeat, 0);
+    else {
+      let removeDelta = 0;
+      let rmPromises = [];
+
+      for (let i = 0, ii = splices.length; i < ii; ++i) {
+        let splice = splices[i];
+        let removed = splice.removed;
+        let removedLength = removed.length;
+        for (let j = 0, jj = removedLength; j < jj; ++j) {
+          let viewOrPromise = this._removeViewAt(repeat, splice.index + removeDelta + rmPromises.length, true, j, removedLength);
+          if (viewOrPromise instanceof Promise) {
+            rmPromises.push(viewOrPromise);
+          }
+        }
+        removeDelta -= splice.addedCount;
+      }
+
+      if (rmPromises.length > 0) {
+        return Promise.all(rmPromises).then(() => {
+          this._handleAddedSplices(repeat, array, splices);
+          updateVirtualOverrideContexts(repeat, 0);
+        });
+      }
+      this._handleAddedSplices(repeat, array, splices);
+      updateVirtualOverrideContexts(repeat, 0);
+    }
   }
 
   _removeViewAt(repeat: VirtualRepeat, collectionIndex: number, returnToCache: boolean, j: number, removedLength: number): any {

--- a/dist/commonjs/array-virtual-repeat-strategy.js
+++ b/dist/commonjs/array-virtual-repeat-strategy.js
@@ -118,30 +118,47 @@ var ArrayVirtualRepeatStrategy = exports.ArrayVirtualRepeatStrategy = function (
   ArrayVirtualRepeatStrategy.prototype._runSplices = function _runSplices(repeat, array, splices) {
     var _this3 = this;
 
-    var removeDelta = 0;
-    var rmPromises = [];
+    var allSplicesAreInplace = splices.reduce(function (prev, splice) {
+      return prev && splice.removed.length === splice.addedCount;
+    }, true);
 
-    for (var i = 0, ii = splices.length; i < ii; ++i) {
-      var splice = splices[i];
-      var removed = splice.removed;
-      var removedLength = removed.length;
-      for (var j = 0, jj = removedLength; j < jj; ++j) {
-        var viewOrPromise = this._removeViewAt(repeat, splice.index + removeDelta + rmPromises.length, true, j, removedLength);
-        if (viewOrPromise instanceof Promise) {
-          rmPromises.push(viewOrPromise);
+    if (allSplicesAreInplace) {
+      splices.forEach(function (splice) {
+        for (var collectionIndex = splice.index; collectionIndex < splice.index + splice.addedCount; collectionIndex++) {
+          if (!_this3._isIndexBeforeViewSlot(repeat, repeat.viewSlot, collectionIndex) && !_this3._isIndexAfterViewSlot(repeat, repeat.viewSlot, collectionIndex)) {
+            var viewIndex = _this3._getViewIndex(repeat, repeat.viewSlot, collectionIndex);
+            var overrideContext = (0, _aureliaTemplatingResources.createFullOverrideContext)(repeat, array[collectionIndex], collectionIndex, array.length);
+            repeat.removeView(viewIndex, true, true);
+            repeat.insertView(viewIndex, overrideContext.bindingContext, overrideContext);
+          }
         }
-      }
-      removeDelta -= splice.addedCount;
-    }
-
-    if (rmPromises.length > 0) {
-      return Promise.all(rmPromises).then(function () {
-        _this3._handleAddedSplices(repeat, array, splices);
-        (0, _utilities.updateVirtualOverrideContexts)(repeat, 0);
       });
+    } else {
+      var removeDelta = 0;
+      var rmPromises = [];
+
+      for (var i = 0, ii = splices.length; i < ii; ++i) {
+        var splice = splices[i];
+        var removed = splice.removed;
+        var removedLength = removed.length;
+        for (var j = 0, jj = removedLength; j < jj; ++j) {
+          var viewOrPromise = this._removeViewAt(repeat, splice.index + removeDelta + rmPromises.length, true, j, removedLength);
+          if (viewOrPromise instanceof Promise) {
+            rmPromises.push(viewOrPromise);
+          }
+        }
+        removeDelta -= splice.addedCount;
+      }
+
+      if (rmPromises.length > 0) {
+        return Promise.all(rmPromises).then(function () {
+          _this3._handleAddedSplices(repeat, array, splices);
+          (0, _utilities.updateVirtualOverrideContexts)(repeat, 0);
+        });
+      }
+      this._handleAddedSplices(repeat, array, splices);
+      (0, _utilities.updateVirtualOverrideContexts)(repeat, 0);
     }
-    this._handleAddedSplices(repeat, array, splices);
-    (0, _utilities.updateVirtualOverrideContexts)(repeat, 0);
   };
 
   ArrayVirtualRepeatStrategy.prototype._removeViewAt = function _removeViewAt(repeat, collectionIndex, returnToCache, j, removedLength) {

--- a/dist/temp/aurelia-ui-virtualization.js
+++ b/dist/temp/aurelia-ui-virtualization.js
@@ -270,30 +270,47 @@ var ArrayVirtualRepeatStrategy = exports.ArrayVirtualRepeatStrategy = function (
   ArrayVirtualRepeatStrategy.prototype._runSplices = function _runSplices(repeat, array, splices) {
     var _this3 = this;
 
-    var removeDelta = 0;
-    var rmPromises = [];
+    var allSplicesAreInplace = splices.reduce(function (prev, splice) {
+      return prev && splice.removed.length === splice.addedCount;
+    }, true);
 
-    for (var i = 0, ii = splices.length; i < ii; ++i) {
-      var splice = splices[i];
-      var removed = splice.removed;
-      var removedLength = removed.length;
-      for (var j = 0, jj = removedLength; j < jj; ++j) {
-        var viewOrPromise = this._removeViewAt(repeat, splice.index + removeDelta + rmPromises.length, true, j, removedLength);
-        if (viewOrPromise instanceof Promise) {
-          rmPromises.push(viewOrPromise);
+    if (allSplicesAreInplace) {
+      splices.forEach(function (splice) {
+        for (var collectionIndex = splice.index; collectionIndex < splice.index + splice.addedCount; collectionIndex++) {
+          if (!_this3._isIndexBeforeViewSlot(repeat, repeat.viewSlot, collectionIndex) && !_this3._isIndexAfterViewSlot(repeat, repeat.viewSlot, collectionIndex)) {
+            var viewIndex = _this3._getViewIndex(repeat, repeat.viewSlot, collectionIndex);
+            var overrideContext = (0, _aureliaTemplatingResources.createFullOverrideContext)(repeat, array[collectionIndex], collectionIndex, array.length);
+            repeat.removeView(viewIndex, true, true);
+            repeat.insertView(viewIndex, overrideContext.bindingContext, overrideContext);
+          }
         }
-      }
-      removeDelta -= splice.addedCount;
-    }
-
-    if (rmPromises.length > 0) {
-      return Promise.all(rmPromises).then(function () {
-        _this3._handleAddedSplices(repeat, array, splices);
-        updateVirtualOverrideContexts(repeat, 0);
       });
+    } else {
+      var removeDelta = 0;
+      var rmPromises = [];
+
+      for (var i = 0, ii = splices.length; i < ii; ++i) {
+        var splice = splices[i];
+        var removed = splice.removed;
+        var removedLength = removed.length;
+        for (var j = 0, jj = removedLength; j < jj; ++j) {
+          var viewOrPromise = this._removeViewAt(repeat, splice.index + removeDelta + rmPromises.length, true, j, removedLength);
+          if (viewOrPromise instanceof Promise) {
+            rmPromises.push(viewOrPromise);
+          }
+        }
+        removeDelta -= splice.addedCount;
+      }
+
+      if (rmPromises.length > 0) {
+        return Promise.all(rmPromises).then(function () {
+          _this3._handleAddedSplices(repeat, array, splices);
+          updateVirtualOverrideContexts(repeat, 0);
+        });
+      }
+      this._handleAddedSplices(repeat, array, splices);
+      updateVirtualOverrideContexts(repeat, 0);
     }
-    this._handleAddedSplices(repeat, array, splices);
-    updateVirtualOverrideContexts(repeat, 0);
   };
 
   ArrayVirtualRepeatStrategy.prototype._removeViewAt = function _removeViewAt(repeat, collectionIndex, returnToCache, j, removedLength) {

--- a/package.json
+++ b/package.json
@@ -20,23 +20,10 @@
   },
   "jspm": {
     "registry": "npm",
-    "jspmPackage": true,
     "main": "index",
     "format": "amd",
     "directories": {
       "dist": "dist/amd"
-    },
-    "peerDependencies": {
-      "aurelia-binding": "^1.0.0-beta.1.1.3",
-      "aurelia-dependency-injection": "^1.0.0-beta.1.1.3",
-      "aurelia-framework": "^1.0.0-beta.1.1.3",
-      "aurelia-logging": "^1.0.0-beta.1.1.1",
-      "aurelia-logging-console": "^1.0.0-beta.1.1.4",
-      "aurelia-pal": "^1.0.0-beta.1.2.0",
-      "aurelia-path": "^1.0.0-beta.1.1.0",
-      "aurelia-task-queue": "^1.0.0-beta.1.1.1",
-      "aurelia-templating": "^1.0.0-beta.1.1.1",
-      "aurelia-templating-resources": "^1.0.0-beta.1.1.1"
     },
     "dependencies": {
       "aurelia-binding": "^1.0.0-beta.1.1.3",

--- a/src/array-virtual-repeat-strategy.js
+++ b/src/array-virtual-repeat-strategy.js
@@ -110,10 +110,10 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy {
     // if so, optimise by just replacing affected visible views
     if( allSplicesAreInplace ) {
       splices.forEach( (splice) => {
-        for ( var collectionIndex = splice.index; collectionIndex<splice.index+splice.addedCount; collectionIndex++ ) {
+        for ( let collectionIndex = splice.index; collectionIndex<splice.index+splice.addedCount; collectionIndex++ ) {
           if( !this._isIndexBeforeViewSlot(repeat, repeat.viewSlot, collectionIndex) && !this._isIndexAfterViewSlot(repeat, repeat.viewSlot, collectionIndex) ) {
-            var viewIndex = this._getViewIndex(repeat, repeat.viewSlot, collectionIndex);
-            var overrideContext = createFullOverrideContext(repeat, array[collectionIndex], collectionIndex, array.length);
+            let viewIndex = this._getViewIndex(repeat, repeat.viewSlot, collectionIndex);
+            let overrideContext = createFullOverrideContext(repeat, array[collectionIndex], collectionIndex, array.length);
             repeat.removeView(viewIndex, true, true);            
             repeat.insertView(viewIndex, overrideContext.bindingContext, overrideContext);
           }


### PR DESCRIPTION
…nt affect the array length and buffer sizes

In our use case, most of the mutation to the observed collection is replacing chunks of the underlying array. Essentially I create a fixed sized set of items (known number of results), then lazy load real data into it from remote source based up the current/predicted scroll position.

This change is simple: if and only if mutations only replace items in the array (splice.addedCount===splice.removed.length), then we can assume the top and bottom buffers don't require changes and we can simplify to only update view slots which are currently visible.

I think this is fairly innocuous and seems to work well in our application. However, I'm not yet completely up to scratch with Aurelia's internals, so there may be some glaring error.
