### PR TITLE
perf(array-virtual-repeat-strategy): optimise case where mutations do…

### DIFF
--- a/src/array-virtual-repeat-strategy.js
+++ b/src/array-virtual-repeat-strategy.js
@@ -104,27 +104,53 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy {
     let removeDelta = 0;
     let rmPromises = [];
 
-    for (let i = 0, ii = splices.length; i < ii; ++i) {
+    // do all splices replace existing entries?
+    let allSplicesAreInplace = true;
+    for (let i=0; i<splices.length; i++) {
       let splice = splices[i];
-      let removed = splice.removed;
-      let removedLength = removed.length;
-      for (let j = 0, jj = removedLength; j < jj; ++j) {
-        let viewOrPromise = this._removeViewAt(repeat, splice.index + removeDelta + rmPromises.length, true, j, removedLength);
-        if (viewOrPromise instanceof Promise) {
-          rmPromises.push(viewOrPromise);
+      if( splice.removed.length!==splice.addedCount ) {
+        allSplicesAreInplace = false;  
+        break;
+      }
+    } 
+
+    // if so, optimise by just replacing affected visible views
+    if (allSplicesAreInplace) {
+      for (let i=0; i<splices.length; i++) {
+        let splice = splices[i];
+        for ( let collectionIndex = splice.index; collectionIndex<splice.index+splice.addedCount; collectionIndex++ ) {
+          if( !this._isIndexBeforeViewSlot(repeat, repeat.viewSlot, collectionIndex) && !this._isIndexAfterViewSlot(repeat, repeat.viewSlot, collectionIndex) ) {
+            let viewIndex = this._getViewIndex(repeat, repeat.viewSlot, collectionIndex);
+            let overrideContext = createFullOverrideContext(repeat, array[collectionIndex], collectionIndex, array.length);
+            repeat.removeView(viewIndex, true, true);            
+            repeat.insertView(viewIndex, overrideContext.bindingContext, overrideContext);
+          }
         }
       }
-      removeDelta -= splice.addedCount;
     }
+    else {
+      for (let i = 0, ii = splices.length; i < ii; ++i) {
+        let splice = splices[i];
+        let removed = splice.removed;
+        let removedLength = removed.length;
+        for (let j = 0, jj = removedLength; j < jj; ++j) {
+          let viewOrPromise = this._removeViewAt(repeat, splice.index + removeDelta + rmPromises.length, true, j, removedLength);
+          if (viewOrPromise instanceof Promise) {
+            rmPromises.push(viewOrPromise);
+          }
+        }
+        removeDelta -= splice.addedCount;
+      }
 
-    if (rmPromises.length > 0) {
-      return Promise.all(rmPromises).then(() => {
-        this._handleAddedSplices(repeat, array, splices);
-        updateVirtualOverrideContexts(repeat, 0);
-      });
+      if (rmPromises.length > 0) {
+        return Promise.all(rmPromises).then(() => {
+          this._handleAddedSplices(repeat, array, splices);
+          updateVirtualOverrideContexts(repeat, 0);
+        });
+      }
+      this._handleAddedSplices(repeat, array, splices);
+      updateVirtualOverrideContexts(repeat, 0);
     }
-    this._handleAddedSplices(repeat, array, splices);
-    updateVirtualOverrideContexts(repeat, 0);
   }
 
   _removeViewAt(repeat: VirtualRepeat, collectionIndex: number, returnToCache: boolean, j: number, removedLength: number): any {

--- a/src/array-virtual-repeat-strategy.js
+++ b/src/array-virtual-repeat-strategy.js
@@ -104,27 +104,52 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy {
     let removeDelta = 0;
     let rmPromises = [];
 
-    for (let i = 0, ii = splices.length; i < ii; ++i) {
-      let splice = splices[i];
-      let removed = splice.removed;
-      let removedLength = removed.length;
-      for (let j = 0, jj = removedLength; j < jj; ++j) {
-        let viewOrPromise = this._removeViewAt(repeat, splice.index + removeDelta + rmPromises.length, true, j, removedLength);
-        if (viewOrPromise instanceof Promise) {
-          rmPromises.push(viewOrPromise);
+    // do all splices replace existing entries?
+    let allSplicesAreInplace = true;
+    for (let i=0; i<splices.length; i++) {
+      if( splice.removed.length!==splice.addedCount ) {
+        allSplicesAreInplace = false;  
+        break;
+      }
+    } 
+
+    // if so, optimise by just replacing affected visible views
+    if (allSplicesAreInplace) {
+      for (let i=0; i<splices.length; i++) {
+        let splice = splices[i];
+        for ( let collectionIndex = splice.index; collectionIndex<splice.index+splice.addedCount; collectionIndex++ ) {
+          if( !this._isIndexBeforeViewSlot(repeat, repeat.viewSlot, collectionIndex) && !this._isIndexAfterViewSlot(repeat, repeat.viewSlot, collectionIndex) ) {
+            let viewIndex = this._getViewIndex(repeat, repeat.viewSlot, collectionIndex);
+            let overrideContext = createFullOverrideContext(repeat, array[collectionIndex], collectionIndex, array.length);
+            repeat.removeView(viewIndex, true, true);            
+            repeat.insertView(viewIndex, overrideContext.bindingContext, overrideContext);
+          }
         }
       }
-      removeDelta -= splice.addedCount;
     }
+    else {
+      for (let i = 0, ii = splices.length; i < ii; ++i) {
+        let splice = splices[i];
+        let removed = splice.removed;
+        let removedLength = removed.length;
+        for (let j = 0, jj = removedLength; j < jj; ++j) {
+          let viewOrPromise = this._removeViewAt(repeat, splice.index + removeDelta + rmPromises.length, true, j, removedLength);
+          if (viewOrPromise instanceof Promise) {
+            rmPromises.push(viewOrPromise);
+          }
+        }
+        removeDelta -= splice.addedCount;
+      }
 
-    if (rmPromises.length > 0) {
-      return Promise.all(rmPromises).then(() => {
-        this._handleAddedSplices(repeat, array, splices);
-        updateVirtualOverrideContexts(repeat, 0);
-      });
+      if (rmPromises.length > 0) {
+        return Promise.all(rmPromises).then(() => {
+          this._handleAddedSplices(repeat, array, splices);
+          updateVirtualOverrideContexts(repeat, 0);
+        });
+      }
+      this._handleAddedSplices(repeat, array, splices);
+      updateVirtualOverrideContexts(repeat, 0);
     }
-    this._handleAddedSplices(repeat, array, splices);
-    updateVirtualOverrideContexts(repeat, 0);
   }
 
   _removeViewAt(repeat: VirtualRepeat, collectionIndex: number, returnToCache: boolean, j: number, removedLength: number): any {


### PR DESCRIPTION
Optimise case where mutations dont affect the array length and buffer sizes

In our use case, most of the mutation to the observed collection is replacing chunks of the underlying array. Essentially I create a fixed sized set of items (known number of results), then lazy load real data into it from remote source based up the current/predicted scroll position.

This change is simple: if and only if mutations only replace items in the array (splice.addedCount===splice.removed.length), then we can assume the top and bottom buffers don't require changes and we can simplify to only update view slots which are currently visible.

I think this is fairly innocuous and seems to work well in our application. However, I'm not yet completely up to scratch with Aurelia's internals, so there may be some glaring error.
