### PR TITLE
feat(virtual-repeat): allow 'next' function defined from sub properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If you are running the plugin in the `skeleton-naviagion` project, make sure to 
 #### infinite scroll
 ```html
 <template>
-  <div virtual-repeat.for="item of items" virtual-repeat-next="getMore">
+  <div virtual-repeat.for="item of items" infinite-scroll-next="getMore">
     ${$index} ${item}
   </div>
 </template>
@@ -108,7 +108,7 @@ export class MyVirtualList {
 Or to use an expression, use `.call` as shown below.
 ```html
 <template>
-  <div virtual-repeat.for="item of items" virtual-repeat-next.call="getMore($scrollContext)">
+  <div virtual-repeat.for="item of items" infinite-scroll-next.call="getMore($scrollContext)">
     ${$index} ${item}
   </div>
 </template>
@@ -124,7 +124,7 @@ export class MyVirtualList {
 }
 ```  
 
-The `virtual-repeat-next` attribute can accept a function, a promise, or a function that returns a promise.  
+The `infinite-scroll-next` attribute can accept a function, a promise, or a function that returns a promise.  
 The bound function will be called when the scroll container has reached a point where there are no more items to move into the DOM (i.e. when it reaches the end of a list, either from the top or the bottom).  
 There are three parameters that are passed to the function (`getMore(topIndex, isAtBottom, isAtTop)`) which helps determine the behavior or amount of items to get during scrolling.    
 1. `topIndex` - A integer value that represents the current item that exists at the top of the rendered items in the DOM.  

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ If you are running the plugin in the `skeleton-naviagion` project, make sure to 
   </div>
 </template>
 ```  
-
 ```javascript
 export class MyVirtualList {
     items = ['Foo', 'Bar', 'Baz'];
@@ -105,6 +104,26 @@ export class MyVirtualList {
     }
 }
 ```  
+
+Or to use an expression, use `.call` as shown below.
+```html
+<template>
+  <div virtual-repeat.for="item of items" virtual-repeat-next.call="getMore($scrollContext)">
+    ${$index} ${item}
+  </div>
+</template>
+```  
+```javascript
+export class MyVirtualList {
+    items = ['Foo', 'Bar', 'Baz'];
+    getMore(scrollContext) {
+        for(let i = 0; i < 100; ++i) {
+            this.items.push('item' + i);
+        }
+    }
+}
+```  
+
 The `virtual-repeat-next` attribute can accept a function, a promise, or a function that returns a promise.  
 The bound function will be called when the scroll container has reached a point where there are no more items to move into the DOM (i.e. when it reaches the end of a list, either from the top or the bottom).  
 There are three parameters that are passed to the function (`getMore(topIndex, isAtBottom, isAtTop)`) which helps determine the behavior or amount of items to get during scrolling.    

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "build": {
       "resources": [
         "virtual-repeat",
-        "virtual-repeat-next"
+        "infinite-scroll-next"
       ]
     },
     "documentation": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
     "usedBy": [],
     "build": {
       "resources": [
-        "virtual-repeat"
+        "virtual-repeat",
+        "virtual-repeat-next"
       ]
     },
     "documentation": {

--- a/src/aurelia-ui-virtualization.js
+++ b/src/aurelia-ui-virtualization.js
@@ -1,14 +1,14 @@
 import {VirtualRepeat} from './virtual-repeat';
-import {VirtualRepeatNext} from './virtual-repeat-next';
+import {InfiniteScrollNext} from './infinite-scroll-next';
 
 export function configure(config) {
   config.globalResources(
     './virtual-repeat',
-    './virtual-repeat-next'
+    './infinite-scroll-next'
   );
 }
 
 export {
   VirtualRepeat,
-  VirtualRepeatNext
+  InfiniteScrollNext
 };

--- a/src/infinite-scroll-next.js
+++ b/src/infinite-scroll-next.js
@@ -2,8 +2,8 @@ import {customAttribute} from 'aurelia-templating';
 
 //Placeholder attribute to prohibit use of this attribute name in other places
 
-@customAttribute('virtual-repeat-next')
-export class VirtualRepeatNext {
+@customAttribute('infinite-scroll-next')
+export class InfiniteScrollNext {
 
   constructor() {}
 

--- a/src/virtual-repeat.js
+++ b/src/virtual-repeat.js
@@ -273,7 +273,7 @@ export class VirtualRepeat extends AbstractRepeater {
       if (!this._calledGetMore) {
         let executeGetMore = () => {
           this._calledGetMore = true;
-          let func = (this.view(0) && this.view(0).firstChild.au) ? this.view(0).firstChild.au['virtual-repeat-next'].instruction.attributes['virtual-repeat-next'] : undefined;
+          let func = (this.view(0) && this.view(0).firstChild.au) ? this.view(0).firstChild.au['infinite-scroll-next'].instruction.attributes['infinite-scroll-next'] : undefined;
           let topIndex = this._first;
           let isAtBottom = this._bottomBufferHeight === 0;
           let isAtTop = this._isAtTop;
@@ -288,7 +288,7 @@ export class VirtualRepeat extends AbstractRepeater {
           if (func === undefined) {
             return null;
           } else if (typeof func === 'string') {
-            let getMoreFuncName = this.view(0).firstChild.getAttribute('virtual-repeat-next');
+            let getMoreFuncName = this.view(0).firstChild.getAttribute('infinite-scroll-next');
             let funcCall = this.scope.overrideContext.bindingContext[getMoreFuncName];
 
             if (typeof funcCall === 'function') {
@@ -301,13 +301,13 @@ export class VirtualRepeat extends AbstractRepeater {
                 });
               }
             } else {
-              throw new Error("'virtual-repeat-next' must be a function or evaluate to one");
+              throw new Error("'infinite-scroll-next' must be a function or evaluate to one");
             }
           } else if (func.sourceExpression) {
             this._calledGetMore = false; //Reset for the next time
             return func.sourceExpression.evaluate(this.scope);
           } else {
-            throw new Error("'virtual-repeat-next' must be a function or evaluate to one");
+            throw new Error("'infinite-scroll-next' must be a function or evaluate to one");
           }
           return null;
         };

--- a/src/virtual-repeat.js
+++ b/src/virtual-repeat.js
@@ -271,26 +271,43 @@ export class VirtualRepeat extends AbstractRepeater {
   _getMore(): void {
     if (this.isLastIndex || this._first === 0) {
       if (!this._calledGetMore) {
-        let getMoreFunc = this.view(0).firstChild.getAttribute('virtual-repeat-next');
-        if (!getMoreFunc) {
-          return;
-        }
-        let getMore = this.scope.overrideContext.bindingContext[getMoreFunc];
         let executeGetMore = () => {
           this._calledGetMore = true;
-          if (getMore instanceof Promise) {
-            return getMore.then(() => {
-              this._calledGetMore = false; //Reset for the next time
-            });
-          } else if (typeof getMore === 'function') {
-            let result = getMore.bind(this.scope.overrideContext.bindingContext)(this._first, this._bottomBufferHeight === 0, this._isAtTop);
-            if (!(result instanceof Promise)) {
-              this._calledGetMore = false; //Reset for the next time
-            } else {
-              return result.then(() => {
+          let func = (this.view(0) && this.view(0).firstChild.au) ? this.view(0).firstChild.au['virtual-repeat-next'].instruction.attributes['virtual-repeat-next'] : undefined;
+          let topIndex = this._first;
+          let isAtBottom = this._bottomBufferHeight === 0;
+          let isAtTop = this._isAtTop;
+          let scrollContext = {
+            topIndex: topIndex,
+            isAtBottom: isAtBottom,
+            isAtTop: isAtTop
+          };
+
+          this.scope.overrideContext.$scrollContext = scrollContext;
+
+          if (func === undefined) {
+            return null;
+          } else if (typeof func === 'string') {
+            let getMoreFuncName = this.view(0).firstChild.getAttribute('virtual-repeat-next');
+            let funcCall = this.scope.overrideContext.bindingContext[getMoreFuncName];
+
+            if (typeof funcCall === 'function') {
+              let result = funcCall.call(this.scope.overrideContext.bindingContext, topIndex, isAtBottom, isAtTop);
+              if (!(result instanceof Promise)) {
                 this._calledGetMore = false; //Reset for the next time
-              });
+              } else {
+                return result.then(() => {
+                  this._calledGetMore = false; //Reset for the next time
+                });
+              }
+            } else {
+              throw new Error("'virtual-repeat-next' must be a function or evaluate to one");
             }
+          } else if (func.sourceExpression) {
+            this._calledGetMore = false; //Reset for the next time
+            return func.sourceExpression.evaluate(this.scope);
+          } else {
+            throw new Error("'virtual-repeat-next' must be a function or evaluate to one");
           }
           return null;
         };

--- a/test/virtual-repeat-integration.spec.js
+++ b/test/virtual-repeat-integration.spec.js
@@ -26,14 +26,9 @@ function createAssertionQueue() {
 let nq = createAssertionQueue();
 
 describe('VirtualRepeat Integration', () => {
-  let component;
-  let virtualRepeat;
-  let viewModel;
   let itemHeight = 100;
-  let create;
-  let items;
 
-  function validateState() {
+  function validateState(virtualRepeat, viewModel) {
     let views = virtualRepeat.viewSlot.children;
     let expectedHeight = viewModel.items.length * itemHeight;
     let topBufferHeight = virtualRepeat.topBuffer.getBoundingClientRect().height;
@@ -63,7 +58,7 @@ describe('VirtualRepeat Integration', () => {
     }
   }
 
-  function validateScrolledState() {
+  function validateScrolledState(virtualRepeat, viewModel) {
     let views = virtualRepeat.viewSlot.children;
     let expectedHeight = viewModel.items.length * itemHeight;
     let topBufferHeight = virtualRepeat.topBuffer.getBoundingClientRect().height;
@@ -94,21 +89,21 @@ describe('VirtualRepeat Integration', () => {
     }
   }
 
-  function validateScroll(done) {
-      let elem = document.getElementById('scrollContainer');
+  function validateScroll(virtualRepeat, viewModel, done, element) {
+      let elem = document.getElementById(element || 'scrollContainer');
       let event = new Event('scroll');
       elem.scrollTop = elem.scrollHeight;
       elem.dispatchEvent(event);
       window.setTimeout(()=>{
           window.requestAnimationFrame(() => {
-              validateScrolledState();
+              validateScrolledState(virtualRepeat, viewModel);
               done();
           });
       });
   }
 
-  function validateScrollUp(done) {
-      let elem = document.getElementById('scrollContainer');
+  function validateScrollUp(virtualRepeat, viewModel, done, element) {
+      let elem = document.getElementById(element || 'scrollContainer');
       let event = new Event('scroll');
       elem.scrollTop = elem.scrollHeight/2; //Scroll down but not far enough to reach bottom and call 'getNext'
       elem.dispatchEvent(event);
@@ -119,7 +114,7 @@ describe('VirtualRepeat Integration', () => {
             elem.dispatchEvent(eventUp);
             window.setTimeout(()=>{
                 window.requestAnimationFrame(() => {
-                  validateScrolledState();
+                  validateScrolledState(virtualRepeat, viewModel);
                   done();
                 });
             });
@@ -127,63 +122,69 @@ describe('VirtualRepeat Integration', () => {
       });
   }
 
-  function validatePush(done) {
+  function validatePush(virtualRepeat, viewModel, done) {
     viewModel.items.push('Foo');
-    nq(() => validateState());
+    nq(() => validateState(virtualRepeat, viewModel));
 
     for(let i = 0; i < 5; ++i) {
       viewModel.items.push(`Foo ${i}`);
     }
 
-    nq(() => validateState());
+    nq(() => validateState(virtualRepeat, viewModel));
     nq(() => done());
   }
 
-  function validatePop(done) {
+  function validatePop(virtualRepeat, viewModel, done) {
     viewModel.items.pop();
-      nq(() => validateState());
+      nq(() => validateState(virtualRepeat, viewModel));
       nq(() => viewModel.items.pop());
-      nq(() => validateState());
+      nq(() => validateState(virtualRepeat, viewModel));
       nq(() => viewModel.items.pop());
-      nq(() => validateState());
+      nq(() => validateState(virtualRepeat, viewModel));
       nq(() => done());
   }
 
-  function validateUnshift(done) {
+  function validateUnshift(virtualRepeat, viewModel, done) {
     viewModel.items.unshift('z');
-      nq(() => validateState());
+      nq(() => validateState(virtualRepeat, viewModel));
       nq(() => viewModel.items.unshift('y', 'x'));
-      nq(() => validateState());
+      nq(() => validateState(virtualRepeat, viewModel));
       nq(() => viewModel.items.unshift());
-      nq(() => validateState());
+      nq(() => validateState(virtualRepeat, viewModel));
       nq(() => done());
   }
 
-  function validateShift(done) {
+  function validateShift(virtualRepeat, viewModel, done) {
     viewModel.items.shift();
-      nq(() => validateState());
+      nq(() => validateState(virtualRepeat, viewModel));
       nq(() => viewModel.items.shift());
-      nq(() => validateState());
+      nq(() => validateState(virtualRepeat, viewModel));
       nq(() => viewModel.items.shift());
-      nq(() => validateState());
+      nq(() => validateState(virtualRepeat, viewModel));
       nq(() => done());
   }
 
-  function validateReverse(done) {
+  function validateReverse(virtualRepeat, viewModel, done) {
     viewModel.items.reverse();
-      nq(() => validateState());
+      nq(() => validateState(virtualRepeat, viewModel));
       nq(() => done());
   }
 
-  function validateSplice(done) {
+  function validateSplice(virtualRepeat, viewModel, done) {
     viewModel.items.splice(2, 1, 'x', 'y');
-      nq(() => validateState());
+      nq(() => validateState(virtualRepeat, viewModel));
       nq(() => done());
   }
 
   describe('iterating div', () => {
+    let component;
+    let virtualRepeat;
+    let viewModel;
+    let create;
+    let items;
+
     beforeEach(() => {
-       items = [];
+      items = [];
       for(let i = 0; i < 1000; ++i) {
         items.push('item' + i);
       }
@@ -198,11 +199,15 @@ describe('VirtualRepeat Integration', () => {
       });
     });
 
+    afterEach(() => {
+      component.cleanUp();
+    });
+
     describe('handles delete', () => {
       it('can delete one at start', done => {
         create.then(() => {
           viewModel.items.splice(0, 1);
-          nq(() => validateState());
+          nq(() => validateState(virtualRepeat, viewModel));
           nq(() => done());
         });
       });
@@ -210,7 +215,7 @@ describe('VirtualRepeat Integration', () => {
       it('can delete one at end', done => {
         create.then(() => {
           viewModel.items.splice(viewModel.items.length - 1, 1);
-          nq(() => validateState());
+          nq(() => validateState(virtualRepeat, viewModel));
           nq(() => done());
         });
       });
@@ -219,7 +224,7 @@ describe('VirtualRepeat Integration', () => {
         create.then(() => {
           viewModel.items.splice(0, 1);
           viewModel.items.splice(0, 1);
-          nq(() => validateState());
+          nq(() => validateState(virtualRepeat, viewModel));
           nq(() => done());
         });
       });
@@ -228,7 +233,7 @@ describe('VirtualRepeat Integration', () => {
         create.then(() => {
           viewModel.items.splice(viewModel.items.length - 1, 1);
           viewModel.items.splice(viewModel.items.length - 1, 1);
-          nq(() => validateState());
+          nq(() => validateState(virtualRepeat, viewModel));
           nq(() => done());
         });
       });
@@ -239,7 +244,7 @@ describe('VirtualRepeat Integration', () => {
           for(let i = 0; i < deleteCount; ++i) {
             viewModel.items.splice(0, 1);
           }
-          nq(() => validateState());
+          nq(() => validateState(virtualRepeat, viewModel));
           nq(() => done());
         });
       });
@@ -250,7 +255,7 @@ describe('VirtualRepeat Integration', () => {
           for(let i = 0; i < deleteCount; ++i) {
             viewModel.items.splice(0, 1);
           }
-          nq(() => validateState());
+          nq(() => validateState(virtualRepeat, viewModel));
           nq(() => done());
         });
       });
@@ -261,43 +266,45 @@ describe('VirtualRepeat Integration', () => {
           for(let i = 0; i < deleteCount; ++i) {
             viewModel.items.splice(0, 1);
           }
-          nq(() => validateState());
+          nq(() => validateState(virtualRepeat, viewModel));
           nq(() => done());
         });
       });
 
     });
 
-    afterEach(() => {
-      component.cleanUp();
-    });
-
     it('handles push', done => {
-      create.then(() => validatePush(done));
+      create.then(() => validatePush(virtualRepeat, viewModel, done));
     });
 
     it('handles pop', done => {
-      create.then(() => validatePop(done));
+      create.then(() => validatePop(virtualRepeat, viewModel, done));
     });
 
     it('handles unshift', done => {
-      create.then(() => validateUnshift(done));
+      create.then(() => validateUnshift(virtualRepeat, viewModel, done));
     });
 
     it('handles shift', done => {
-      create.then(() => validateShift(done));
+      create.then(() => validateShift(virtualRepeat, viewModel, done));
     });
 
     it('handles reverse', done => {
-      create.then(() => validateReverse(done));
+      create.then(() => validateReverse(virtualRepeat, viewModel, done));
     });
 
     it('handles splice', done => {
-      create.then(() => validateSplice(done));
+      create.then(() => validateSplice(virtualRepeat, viewModel, done));
     });
   });
 
   describe('iterating table', () => {
+    let component;
+    let virtualRepeat;
+    let viewModel;
+    let create;
+    let items;
+
     beforeEach(() => {
 
       items = [];
@@ -320,13 +327,19 @@ describe('VirtualRepeat Integration', () => {
     });
 
     it('handles push', done => {
-      create.then(() => validatePush(done));
+      create.then(() => validatePush(virtualRepeat, viewModel, done));
     });
   });
 
   describe('value converters', () => {
+    let component;
+    let virtualRepeat;
+    let viewModel;
+    let create;
+    let items;
+
     beforeEach(() => {
-       items = [];
+      items = [];
       for(let i = 0; i < 1000; ++i) {
         items.push('item' + i);
       }
@@ -346,150 +359,206 @@ describe('VirtualRepeat Integration', () => {
     });
 
     it('handles push', done => {
-      create.then(() => validatePush(done));
+      create.then(() => validatePush(virtualRepeat, viewModel, done));
     });
 
     it('handles pop', done => {
-      create.then(() => validatePop(done));
+      create.then(() => validatePop(virtualRepeat, viewModel, done));
     });
 
     it('handles unshift', done => {
       create.then(() => {
         viewModel.items.unshift('z');
-        nq(() => validateState());
+        nq(() => validateState(virtualRepeat, viewModel));
         nq(() => done());
       });
     });
 
     it('handles shift', done => {
-      create.then(() => validateShift(done));
+      create.then(() => validateShift(virtualRepeat, viewModel, done));
     });
 
     it('handles reverse', done => {
-      create.then(() => validateReverse(done));
+      create.then(() => validateReverse(virtualRepeat, viewModel, done));
     });
 
     it('handles splice', done => {
-      create.then(() => validateSplice(done));
+      create.then(() => validateSplice(virtualRepeat, viewModel, done));
     });
   });
 
   describe('infinite scroll', () =>{
-      let vm;
-      let promisedVm;
-      let promisedComponent;
-      let promisedCreate;
-      let promisedVirtualRepeat;
-      let promisedViewModel;
-      beforeEach(() => {
-        items = [];
-        vm = {
-            items: items,
-            getNextPage: function(){
+    let component;
+    let virtualRepeat;
+    let viewModel;
+    let create;
+    let items;
+
+    let vm;
+    let nestedVm;
+    let nestedComponent;
+    let nestedCreate;
+    let nestedVirtualRepeat;
+    let nestedViewModel;
+    let promisedVm;
+    let promisedComponent;
+    let promisedCreate;
+    let promisedVirtualRepeat;
+    let promisedViewModel;
+    beforeEach(() => {
+      items = [];
+      vm = {
+          items: items,
+          getNextPage: function(){
+            let itemLength = this.items.length;
+            for(let i = 0; i < 100; ++i) {
+                let itemNum = itemLength + i;
+                this.items.push('item' + itemNum);
+            }
+          }
+      };
+      nestedVm = {
+        items: items,
+        bar: [1],
+        getNextPage: function(topIndex, isAtBottom, isAtTop){
+          let itemLength = this.items.length;
+          for(let i = 0; i < 100; ++i) {
+              let itemNum = itemLength + i;
+              this.items.push('item' + itemNum);
+          }
+        }
+      };
+      promisedVm = {
+          items: items,
+          test: '2',
+          getNextPage: function(){
+            return new Promise((resolve, reject) => {
               let itemLength = this.items.length;
               for(let i = 0; i < 100; ++i) {
                   let itemNum = itemLength + i;
                   this.items.push('item' + itemNum);
               }
-            }
-        };
-        promisedVm = {
-            items: items,
-            getNextPage: function(){
-              console.log('here');
-              return new Promise((resolve, reject) => {
-                let itemLength = this.items.length;
-                for(let i = 0; i < 100; ++i) {
-                    let itemNum = itemLength + i;
-                    this.items.push('item' + itemNum);
-                }
-                resolve(true);
-              });
-            }
-        };
-        for(let i = 0; i < 1000; ++i) {
-          items.push('item' + i);
-        }
-
-        spyOn(vm, 'getNextPage').and.callThrough();
-
-        component = StageComponent
-          .withResources(['src/virtual-repeat', 'src/virtual-repeat-next'])
-          .inView(`<div id="scrollContainer" style="height: 500px; overflow-y: scroll">
-                        <div style="height: ${itemHeight}px;" virtual-repeat.for="item of items" virtual-repeat-next="getNextPage">\${item}</div>
-                    </div>`)
-          .boundTo(vm);
-        promisedComponent = StageComponent
-          .withResources(['src/virtual-repeat', 'src/virtual-repeat-next'])
-          .inView(`<div id="scrollContainer" style="height: 500px; overflow-y: scroll">
-                        <div style="height: ${itemHeight}px;" virtual-repeat.for="item of items" virtual-repeat-next="getNextPage">\${item}</div>
-                    </div>`)
-          .boundTo(promisedVm);
-
-        create = component.create().then(() => {
-          virtualRepeat = component.sut;
-          viewModel = component.viewModel;
-          spyOn(virtualRepeat, '_onScroll').and.callThrough();
-        });
-        promisedCreate = promisedComponent.create().then(() => {
-          promisedVirtualRepeat = promisedComponent.sut;
-          promisedViewModel = promisedComponent.viewModel;
-        });
-      });
-
-      afterEach(() => {
-        component.cleanUp();
-        promisedComponent.cleanUp();
-      });
-
-      it('handles scrolling', done => {
-          create.then(() => {
-              validateScroll(() => {
-                  expect(virtualRepeat._onScroll).toHaveBeenCalled();
-                  done();
-              })
-          });
-      });
-      it('handles getting next data set', done => {
-          create.then(() => {
-              validateScroll(() => {
-                  expect(vm.getNextPage).toHaveBeenCalled();
-                  done();
-              })
-          });
-      });
-      it('handles getting next data set scrolling up', done => {
-        create.then(() => {
-            validateScrollUp(() => {
-              var args = vm.getNextPage.calls.argsFor(0);
-              expect(args[0]).toEqual(0);
-              expect(args[1]).toBe(false);
-              expect(args[2]).toBe(true);
-              done();
+              resolve(true);
             });
-        });
+          }
+      };
+      for(let i = 0; i < 1000; ++i) {
+        items.push('item' + i);
+      }
+
+      spyOn(vm, 'getNextPage').and.callThrough();
+      spyOn(nestedVm, 'getNextPage').and.callThrough();
+
+      component = StageComponent
+        .withResources(['src/virtual-repeat', 'src/virtual-repeat-next'])
+        .inView(`<div id="scrollContainer" style="height: 500px; overflow-y: scroll">
+                      <div style="height: ${itemHeight}px;" virtual-repeat.for="item of items" virtual-repeat-next="getNextPage">\${item}</div>
+                  </div>`)
+        .boundTo(vm);
+      nestedComponent = StageComponent
+        .withResources(['src/virtual-repeat', 'src/virtual-repeat-next'])
+        .inView(`<div id="scrollContainerNested" style="height: 500px; overflow-y: scroll" repeat.for="foo of bar">
+                      <div style="height: ${itemHeight}px;" virtual-repeat.for="item of items" virtual-repeat-next.call="$parent.getNextPage($scrollContext)">\${item}</div>
+                  </div>`)
+        .boundTo(nestedVm);
+      promisedComponent = StageComponent
+        .withResources(['src/virtual-repeat', 'src/virtual-repeat-next'])
+        .inView(`<div id="scrollContainerPromise" style="height: 500px; overflow-y: scroll">
+                      <div style="height: ${itemHeight}px;" virtual-repeat.for="item of items" virtual-repeat-next="getNextPage">\${item}</div>
+                  </div>`)
+        .boundTo(promisedVm);
+
+      create = component.create().then(() => {
+        virtualRepeat = component.sut;
+        viewModel = component.viewModel;
+        spyOn(virtualRepeat, '_onScroll').and.callThrough();
       });
-      it('handles getting next data set with promises', done => {
-          promisedCreate.then(() => {
-              validateScroll(() => {
-                //Jasmine spies seem to not be working with returned promises and getting the instance of them, causing regular checks on getNextPage to fail
-                expect(promisedVm.items.length).toBe(1100);
-                done();
-              })
-          });
+      nestedCreate = nestedComponent.create().then(() => {
+        nestedVirtualRepeat = nestedComponent.sut.view(0).controllers[0].viewModel;
+        nestedViewModel = nestedComponent.viewModel;
       });
-      it('passes the current index and location state', done => {
+      promisedCreate = promisedComponent.create().then(() => {
+        promisedVirtualRepeat = promisedComponent.sut;
+        promisedViewModel = promisedComponent.viewModel;
+      });
+    });
+
+    afterEach(() => {
+      component.cleanUp();
+      nestedComponent.cleanUp();
+      promisedComponent.cleanUp();
+    });
+
+    it('handles scrolling', done => {
         create.then(() => {
-            validateScroll(() => {
-              //Taking into account 1 index difference due to default styles on browsers causing small margins of error
-              var args = vm.getNextPage.calls.argsFor(0);
-              expect(args[0]).toBeGreaterThan(988);
-              expect(args[0]).toBeLessThan(991);
-              expect(args[1]).toBe(true);
-              expect(args[2]).toBe(false);
-              done();
+            validateScroll(virtualRepeat, viewModel, () => {
+                expect(virtualRepeat._onScroll).toHaveBeenCalled();
+                done();
             })
         });
-      })
+    });
+    it('handles getting next data set', done => {
+        create.then(() => {
+            validateScroll(virtualRepeat, viewModel, () => {
+                expect(vm.getNextPage).toHaveBeenCalled();
+                done();
+            })
+        });
+    });
+    it('handles getting next data set from nested function', done => {
+        nestedCreate.then(() => {
+            validateScroll(nestedVirtualRepeat, nestedViewModel, () => {
+                expect(nestedVm.getNextPage).toHaveBeenCalled();
+                done();
+            }, 'scrollContainerNested')
+        });
+    });
+    it('handles getting next data set scrolling up', done => {
+      create.then(() => {
+          validateScrollUp(virtualRepeat, viewModel, () => {
+            var args = vm.getNextPage.calls.argsFor(0);
+            expect(args[0]).toEqual(0);
+            expect(args[1]).toBe(false);
+            expect(args[2]).toBe(true);
+            done();
+          });
+      });
+    });
+    it('handles getting next data set with promises', done => {
+        promisedCreate.then(() => {
+            validateScroll(promisedVirtualRepeat, promisedViewModel, () => {
+              //Jasmine spies seem to not be working with returned promises and getting the instance of them, causing regular checks on getNextPage to fail
+              expect(promisedVm.items.length).toBe(1100);
+              done();
+            }, 'scrollContainerPromise')
+        });
+    });
+    it('passes the current index and location state', done => {
+      create.then(() => {
+          validateScroll(virtualRepeat, viewModel, () => {
+            //Taking into account 1 index difference due to default styles on browsers causing small margins of error
+            var args = vm.getNextPage.calls.argsFor(0);
+            expect(args[0]).toBeGreaterThan(988);
+            expect(args[0]).toBeLessThan(991);
+            expect(args[1]).toBe(true);
+            expect(args[2]).toBe(false);
+            done();
+          })
+      });
+    });
+    it('passes context information when using call', done => {
+        nestedCreate.then(() => {
+            validateScroll(nestedVirtualRepeat, nestedViewModel, () => {
+              //Taking into account 1 index difference due to default styles on browsers causing small margins of error
+              expect(nestedVm.getNextPage).toHaveBeenCalled();
+              var scrollContext = nestedVm.getNextPage.calls.argsFor(0)[0];
+              expect(scrollContext.topIndex).toBeGreaterThan(988);
+              expect(scrollContext.topIndex).toBeLessThan(991);
+              expect(scrollContext.isAtBottom).toBe(true);
+              expect(scrollContext.isAtTop).toBe(false);
+              done();
+            }, 'scrollContainerNested')
+        });
+    });
   })
 });

--- a/test/virtual-repeat-integration.spec.js
+++ b/test/virtual-repeat-integration.spec.js
@@ -450,21 +450,21 @@ describe('VirtualRepeat Integration', () => {
       spyOn(nestedVm, 'getNextPage').and.callThrough();
 
       component = StageComponent
-        .withResources(['src/virtual-repeat', 'src/virtual-repeat-next'])
+        .withResources(['src/virtual-repeat', 'src/infinite-scroll-next'])
         .inView(`<div id="scrollContainer" style="height: 500px; overflow-y: scroll">
-                      <div style="height: ${itemHeight}px;" virtual-repeat.for="item of items" virtual-repeat-next="getNextPage">\${item}</div>
+                      <div style="height: ${itemHeight}px;" virtual-repeat.for="item of items" infinite-scroll-next="getNextPage">\${item}</div>
                   </div>`)
         .boundTo(vm);
       nestedComponent = StageComponent
-        .withResources(['src/virtual-repeat', 'src/virtual-repeat-next'])
+        .withResources(['src/virtual-repeat', 'src/infinite-scroll-next'])
         .inView(`<div id="scrollContainerNested" style="height: 500px; overflow-y: scroll" repeat.for="foo of bar">
-                      <div style="height: ${itemHeight}px;" virtual-repeat.for="item of items" virtual-repeat-next.call="$parent.getNextPage($scrollContext)">\${item}</div>
+                      <div style="height: ${itemHeight}px;" virtual-repeat.for="item of items" infinite-scroll-next.call="$parent.getNextPage($scrollContext)">\${item}</div>
                   </div>`)
         .boundTo(nestedVm);
       promisedComponent = StageComponent
-        .withResources(['src/virtual-repeat', 'src/virtual-repeat-next'])
+        .withResources(['src/virtual-repeat', 'src/infinite-scroll-next'])
         .inView(`<div id="scrollContainerPromise" style="height: 500px; overflow-y: scroll">
-                      <div style="height: ${itemHeight}px;" virtual-repeat.for="item of items" virtual-repeat-next="getNextPage">\${item}</div>
+                      <div style="height: ${itemHeight}px;" virtual-repeat.for="item of items" infinite-scroll-next="getNextPage">\${item}</div>
                   </div>`)
         .boundTo(promisedVm);
 


### PR DESCRIPTION
Allow ‘virtual-repeat-next' function to allow sub properties, i.e.
`virtual-repeat-next=“foo.bar.getNext”`

Fixes an issue where if you were using `virtual-repeat` inside a custom element, and your function for getting more existed on the parent, you couldn't directly reference the function.
Example:
Previously broken due to inability to parse `$parent.getMore`

``` html
<li virtual-repeat.for='item of items' virtual-repeat-next='$parent.getMore'>${item}</li>
```

Now fixed. Same syntax, but can parse the bindable property to find the correct function.

``` html
<li virtual-repeat.for='item of items' virtual-repeat-next='$parent.getMore'>${item}</li>
```
