### PR TITLE
fix(virtual-repeat): make infinite scroll work with initial small page size

### DIFF
--- a/src/virtual-repeat.js
+++ b/src/virtual-repeat.js
@@ -241,6 +241,7 @@ export class VirtualRepeat extends AbstractRepeater {
       }
     } else if (this._scrollingUp) {
       let viewsToMove = this._lastRebind - this._first;
+      let initialScrollState = this.isLastIndex === undefined; //Use for catching initial scroll state where a small page size might cause _getMore not to fire.
       if (this._switchedDirection) {
         if (this.isLastIndex) {
           viewsToMove = this.items.length - this._first - this.elementsInView;
@@ -254,7 +255,8 @@ export class VirtualRepeat extends AbstractRepeater {
       this.movedViewsCount = movedViewsCount;
       let adjustHeight = movedViewsCount < viewsToMove ? this._topBufferHeight : itemHeight * movedViewsCount;
       if (viewsToMove > 0) {
-        this._getMore();
+        let force = this.movedViewsCount === 0 && initialScrollState && this._first <= 0 ? true : false;
+        this._getMore(force);
       }
       this._switchedDirection = false;
       this._topBufferHeight = this._topBufferHeight - adjustHeight;
@@ -268,8 +270,8 @@ export class VirtualRepeat extends AbstractRepeater {
     this._ticking = false;
   }
 
-  _getMore(): void {
-    if (this.isLastIndex || this._first === 0) {
+  _getMore(force): void {
+    if (this.isLastIndex || this._first === 0 || force) {
       if (!this._calledGetMore) {
         let executeGetMore = () => {
           this._calledGetMore = true;

--- a/test/virtual-repeat-integration.spec.js
+++ b/test/virtual-repeat-integration.spec.js
@@ -533,6 +533,18 @@ describe('VirtualRepeat Integration', () => {
             }, 'scrollContainerPromise')
         });
     });
+    it('handles getting next data set with small page size', done => {
+      vm.items = [];
+      for(let i = 0; i < 5; ++i) {
+        vm.items.push('item' + i);
+      }
+      create.then(() => {
+        validateScroll(virtualRepeat, viewModel, () => {
+          expect(vm.getNextPage).toHaveBeenCalled();
+          done();
+        })
+      });
+    });
     it('passes the current index and location state', done => {
       create.then(() => {
           validateScroll(virtualRepeat, viewModel, () => {


### PR DESCRIPTION
If the initial page size is too small, where there are no views to move
into the DOM, then the `getMore` function won’t be fired correctly,
resulting in no additional pages being retrieved. By reacting to an
initial, we can catch this event and force the `getMore` function to be
called.
