### PR TITLE
moving _itemsLength initialization a few lines down in calcinitialheights to fix scolling glitch

### DIFF
--- a/src/virtual-repeat.js
+++ b/src/virtual-repeat.js
@@ -410,7 +410,6 @@ export class VirtualRepeat extends AbstractRepeater {
       return;
     }
     this._hasCalculatedSizes = true;
-    this._itemsLength = itemsLength;
     let firstViewElement = this.view(0).lastChild;
     this.itemHeight = calcOuterHeight(firstViewElement);
     if (this.itemHeight <= 0) {
@@ -423,6 +422,7 @@ export class VirtualRepeat extends AbstractRepeater {
       }, 500);
       return;
     }
+    this._itemsLength = itemsLength;
     this.scrollContainerHeight = this._fixedHeightContainer ? this._calcScrollHeight(this.scrollContainer) : document.documentElement.clientHeight;
     this.elementsInView = Math.ceil(this.scrollContainerHeight / this.itemHeight) + 1;
     this._viewsLength = (this.elementsInView * 2) + this._bufferSize;


### PR DESCRIPTION
I had a list using virtual-repeat that was being re-initialized quite a bit based on user input.  The list initially loaded all of my array's contents, and then would get narrowed down based on filters.  I found that the list was populating fine, but the buffer height would not readjust from what it was originally when whole list was loaded. This caused the scrollbar to look like the entire list was still there.