### PR TITLE
fix: recalute height when source array is re-initialized

### DIFF
--- a/src/virtual-repeat.js
+++ b/src/virtual-repeat.js
@@ -423,6 +423,7 @@ export class VirtualRepeat extends AbstractRepeater {
       }, 500);
       return;
     }
+    this._itemsLength = itemsLength;
     this.scrollContainerHeight = this._fixedHeightContainer ? this._calcScrollHeight(this.scrollContainer) : document.documentElement.clientHeight;
     this.elementsInView = Math.ceil(this.scrollContainerHeight / this.itemHeight) + 1;
     this._viewsLength = (this.elementsInView * 2) + this._bufferSize;


### PR DESCRIPTION
I had a list using virtual-repeat that was being re-initialized quite a bit based on user input. The list initially loaded all of my array's contents, and then would get narrowed down based on filters. I found that the list was populating fine, but the buffer height would not readjust from what it was originally when whole list was loaded. This caused the scrollbar to look like the entire list was still there.