### PR TITLE
fix(array-virtual-repeat-strategy): instanceMutated

### DIFF
--- a/src/array-virtual-repeat-strategy.js
+++ b/src/array-virtual-repeat-strategy.js
@@ -171,7 +171,7 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy {
     if (!this._isIndexBeforeViewSlot(repeat, viewSlot, collectionIndex) && !this._isIndexAfterViewSlot(repeat, viewSlot, collectionIndex)) {
       let viewIndex = this._getViewIndex(repeat, viewSlot, collectionIndex);
       viewOrPromise = repeat.removeView(viewIndex, returnToCache);
-      if (repeat.items.length > viewCount) {
+      if (repeat.items.length >= viewCount) {
         // TODO: do not trigger view lifecycle here
         let collectionAddIndex;
         if (repeat._bottomBufferHeight > repeat.itemHeight) {
@@ -180,10 +180,8 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy {
             let lastViewItem = repeat._getLastViewItem();
             collectionAddIndex = repeat.items.indexOf(lastViewItem) + 1;
           } else {
-            collectionAddIndex = j + addedLength;
-            if (collectionAddIndex >= repeat.items.length) {
-              collectionAddIndex = repeat.items.length - repeat._viewsLength - 1 + collectionAddIndex;
-            }
+            let offset = Math.max(0, repeat._viewsLength - repeat.items.length);
+            collectionAddIndex = j - offset + addedLength;
           }
           repeat._bottomBufferHeight = repeat._bottomBufferHeight - (repeat.itemHeight);
         } else if (repeat._topBufferHeight > 0) {

--- a/src/array-virtual-repeat-strategy.js
+++ b/src/array-virtual-repeat-strategy.js
@@ -247,7 +247,7 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy {
         let hasDistanceToBottomViewPort = getElementDistanceToBottomViewPort(repeat.templateStrategy.getLastElement(repeat.bottomBuffer)) > 0;
         if (repeat.viewCount() === 0 || (!this._isIndexBeforeViewSlot(repeat, viewSlot, addIndex) && !this._isIndexAfterViewSlot(repeat, viewSlot, addIndex)) || hasDistanceToBottomViewPort)  {
           let overrideContext = createFullOverrideContext(repeat, array[addIndex], addIndex, arrayLength);
-          repeat.insertView(addIndex, overrideContext.bindingContext, overrideContext);
+          repeat.insertView(this._getViewIndex(repeat, viewSlot, addIndex), overrideContext.bindingContext, overrideContext);
           if (!repeat._hasCalculatedSizes) {
             repeat._calcInitialHeights(1);
           } else if (repeat.viewCount() > repeat._viewsLength) {
@@ -259,6 +259,7 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy {
               repeat.removeView(repeat.viewCount() - 1, true, true);
               repeat._bottomBufferHeight = repeat._bottomBufferHeight + repeat.itemHeight;
             }
+            repeat.isLastIndex = false;
           }
         } else if (this._isIndexBeforeViewSlot(repeat, viewSlot, addIndex)) {
           repeat._topBufferHeight = repeat._topBufferHeight + repeat.itemHeight;

--- a/src/array-virtual-repeat-strategy.js
+++ b/src/array-virtual-repeat-strategy.js
@@ -133,7 +133,7 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy {
         let removed = splice.removed;
         let removedLength = removed.length;
         for (let j = 0, jj = removedLength; j < jj; ++j) {
-          let viewOrPromise = this._removeViewAt(repeat, splice.index + removeDelta + rmPromises.length, true, j, removedLength);
+          let viewOrPromise = this._removeViewAt(repeat, splice.index + removeDelta + rmPromises.length, true, j, removedLength, splice.addedCount);
           if (viewOrPromise instanceof Promise) {
             rmPromises.push(viewOrPromise);
           }
@@ -154,7 +154,7 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy {
     return undefined;
   }
 
-  _removeViewAt(repeat: VirtualRepeat, collectionIndex: number, returnToCache: boolean, j: number, removedLength: number): any {
+  _removeViewAt(repeat: VirtualRepeat, collectionIndex: number, returnToCache: boolean, j: number, removedLength: number, addedLength: number): any {
     let viewOrPromise;
     let view;
     let viewSlot = repeat.viewSlot;
@@ -180,7 +180,10 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy {
             let lastViewItem = repeat._getLastViewItem();
             collectionAddIndex = repeat.items.indexOf(lastViewItem) + 1;
           } else {
-            collectionAddIndex = j;
+            collectionAddIndex = j + addedLength;
+            if (collectionAddIndex >= repeat.items.length) {
+              collectionAddIndex = repeat.items.length - repeat._viewsLength - 1 + collectionAddIndex;
+            }
           }
           repeat._bottomBufferHeight = repeat._bottomBufferHeight - (repeat.itemHeight);
         } else if (repeat._topBufferHeight > 0) {

--- a/test/virtual-repeat-integration.spec.js
+++ b/test/virtual-repeat-integration.spec.js
@@ -77,15 +77,18 @@ describe('VirtualRepeat Integration', () => {
 
     // validate contextual data
     let startingLoc = viewModel.items.indexOf(views[0].bindingContext.item);
-    for (let i = startingLoc; i < views.length; i++) {
-      expect(views[i].bindingContext.item).toBe(viewModel.items[i]);
+    let i = 0;
+    let ii = Math.min(viewModel.items.length - startingLoc, views.length);
+    for (; i < ii; i++) {
+      let itemIndex = startingLoc + i;
+      expect(views[i].bindingContext.item).toBe(viewModel.items[itemIndex]);
       let overrideContext = views[i].overrideContext;
       expect(overrideContext.parentOverrideContext.bindingContext).toBe(viewModel);
       expect(overrideContext.bindingContext).toBe(views[i].bindingContext);
-      let first = i === 0;
-      let last = i === viewModel.items.length - 1;
-      let even = i % 2 === 0;
-      expect(overrideContext.$index).toBe(i);
+      let first = itemIndex === 0;
+      let last = itemIndex === viewModel.items.length - 1;
+      let even = itemIndex % 2 === 0;
+      expect(overrideContext.$index).toBe(itemIndex);
       expect(overrideContext.$first).toBe(first);
       expect(overrideContext.$last).toBe(last);
       expect(overrideContext.$middle).toBe(!first && !last);

--- a/test/virtual-repeat-integration.spec.js
+++ b/test/virtual-repeat-integration.spec.js
@@ -536,6 +536,42 @@ describe('VirtualRepeat Integration', () => {
       });
     });
 
+    it('handles splice removing non-consecutive when scrolled to end', done => {
+      create.then(() => {
+        validateScroll(() => {
+          for (let i = 0, ii = 100; i < ii; i++) {
+            viewModel.items.splice(i + 1, 9);
+          }
+          nq(() => validateScrolledState());
+          nq(() => validateScroll(() => {
+            let views = virtualRepeat.viewSlot.children;
+            setTimeout(() => {
+              expect(views[views.length - 1].bindingContext.item).toBe(viewModel.items[viewModel.items.length - 1]);
+              done();
+            }, 500);
+          }));
+        });
+      });
+    });
+
+    it('handles splice non-consecutive when scrolled to end', done => {
+      create.then(() => {
+        validateScroll(() => {
+          for (let i = 0, ii = 80; i < ii; i++) {
+            viewModel.items.splice(10 * i, 3, i);
+          }
+          nq(() => validateScrolledState());
+          nq(() => validateScroll(() => {
+            let views = virtualRepeat.viewSlot.children;
+            setTimeout(() => {
+              expect(views[views.length - 1].bindingContext.item).toBe(viewModel.items[viewModel.items.length - 1]);
+              done();
+            }, 500);
+          }));
+        });
+      });
+    });
+
     it('handles splice removing many', done => {
       create.then(() => {
         // more items remaining than viewslot capacity
@@ -560,6 +596,26 @@ describe('VirtualRepeat Integration', () => {
       create.then(() => {
         viewModel.items.splice(5, 1000 - virtualRepeat._viewsLength + 10);
         nq(() => expect(virtualRepeat.viewSlot.children.length).toBe(viewModel.items.length));
+        nq(() => validateScrolledState());
+        nq(() => done());
+      });
+    });
+
+    it('handles splice removing non-consecutive', done => {
+      create.then(() => {
+        for (let i = 0, ii = 100; i < ii; i++) {
+          viewModel.items.splice(i + 1, 9);
+        }
+        nq(() => validateScrolledState());
+        nq(() => done());
+      });
+    });
+
+    it('handles splice non-consecutive', done => {
+      create.then(() => {
+        for (let i = 0, ii = 100; i < ii; i++) {
+          viewModel.items.splice(3 * (i + 1), 3, i);
+        }
         nq(() => validateScrolledState());
         nq(() => done());
       });

--- a/test/virtual-repeat-integration.spec.js
+++ b/test/virtual-repeat-integration.spec.js
@@ -495,4 +495,45 @@ describe('VirtualRepeat Integration', () => {
         });
       })
   })
+
+  describe('scrolling div', () => {
+    beforeEach(() => {
+      items = [];
+      for (let i = 0; i < 1000; ++i) {
+        items.push('item' + i);
+      }
+
+      component = StageComponent
+        .withResources(['src/virtual-repeat'])
+        .inView(`<div id="scrollContainer" style="height: 500px; overflow-y: scroll;">
+                   <div style="height: ${itemHeight}px;" virtual-repeat.for="item of items">\${item}</div>
+                 </div>`)
+        .boundTo({ items: items });
+
+      create = component.create().then(() => {
+        virtualRepeat = component.sut;
+        viewModel = component.viewModel;
+      });
+    });
+
+    afterEach(() => {
+      component.cleanUp();
+    });
+
+    it('handles splice when scrolled to end', done => {
+      create.then(() => {
+        validateScroll(() => {
+          viewModel.items.splice(995, 1, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j');
+          nq(() => validateScrolledState());
+          nq(() => validateScroll(() => {
+            let views = virtualRepeat.viewSlot.children;
+            setTimeout(() => {
+              expect(views[views.length - 1].bindingContext.item).toBe(viewModel.items[viewModel.items.length - 1]);
+              done();
+            }, 500);
+          }));
+        });
+      });
+    });
+  });
 });

--- a/test/virtual-repeat-integration.spec.js
+++ b/test/virtual-repeat-integration.spec.js
@@ -538,7 +538,28 @@ describe('VirtualRepeat Integration', () => {
 
     it('handles splice removing many', done => {
       create.then(() => {
-        viewModel.items.splice(5, 990);
+        // more items remaining than viewslot capacity
+        viewModel.items.splice(5, 1000 - virtualRepeat._viewsLength - 10);
+        nq(() => validateScrolledState());
+        nq(() => done());
+      });
+    });
+
+    it('handles splice removing more', done => {
+      // number of items remaining exactly as viewslot capacity
+      create.then(() => {
+        viewModel.items.splice(5, 1000 - virtualRepeat._viewsLength);
+        nq(() => expect(virtualRepeat.viewSlot.children.length).toBe(viewModel.items.length));
+        nq(() => validateScrolledState());
+        nq(() => done());
+      });
+    });
+
+    it('handles splice removing even more', done => {
+      // less items remaining than viewslot capacity
+      create.then(() => {
+        viewModel.items.splice(5, 1000 - virtualRepeat._viewsLength + 10);
+        nq(() => expect(virtualRepeat.viewSlot.children.length).toBe(viewModel.items.length));
         nq(() => validateScrolledState());
         nq(() => done());
       });

--- a/test/virtual-repeat-integration.spec.js
+++ b/test/virtual-repeat-integration.spec.js
@@ -535,5 +535,29 @@ describe('VirtualRepeat Integration', () => {
         });
       });
     });
+
+    it('handles splice removing many', done => {
+      create.then(() => {
+        viewModel.items.splice(5, 990);
+        nq(() => validateScrolledState());
+        nq(() => done());
+      });
+    });
+
+    it('handles splice removing many + add', done => {
+      create.then(() => {
+        viewModel.items.splice(5, 990, 'a', 'b', 'c');
+        nq(() => validateScrolledState());
+        nq(() => done());
+      });
+    });
+
+    it('handles splice remove remaining + add', done => {
+      create.then(() => {
+        viewModel.items.splice(5, 995, 'a', 'b', 'c');
+        nq(() => validateScrolledState());
+        nq(() => done());
+      });
+    });
   });
 });


### PR DESCRIPTION
Mutation is not handled correctly in the following cases:

1) virtual-repeat is already scrolled down
2) many items are removed so that the remaining items fit into the view slot
3) many non-consecutive splices

I guess either 2) or 3) addresses #97 as well.

There are new test cases added for all thee cases.
An issue with validateScrolledState has been fixed as well because of which items were not compared correctly.

I tried to adhere to the current strategy of handling all deletions in all splices first, before processing additions. However, I changed the removal of an item such that the view slot is not immediately filled-up with a new item from the bottom buffer. This is now done by a new method _fillUpViewSlot after handling all removals. This way it was easier to determine the correct items to be added to the end of the view slot.