### PR TITLE
fix(virtual-repeat): Correctly handle items array smaller than elements in view

### DIFF
--- a/src/virtual-repeat.js
+++ b/src/virtual-repeat.js
@@ -262,6 +262,7 @@ export class VirtualRepeat extends AbstractRepeater {
     this._first = this._first < 0 ? 0 : this._first;
     if (this._first > this.items.length - this.elementsInView) {
       this._first = this.items.length - this.elementsInView;
+      this._first = this._first < 0 ? 0 : this._first;
     }
     this._checkScrolling();
     // TODO if and else paths do almost same thing, refactor?

--- a/test/virtual-repeat-integration.spec.js
+++ b/test/virtual-repeat-integration.spec.js
@@ -613,14 +613,26 @@ describe('VirtualRepeat Integration', () => {
     });
     it('handles getting next data set with small page size', done => {
       vm.items = [];
-      for(let i = 0; i < 5; ++i) {
+      for(let i = 0; i < 7; ++i) {
         vm.items.push('item' + i);
       }
       create.then(() => {
         validateScroll(virtualRepeat, viewModel, () => {
           expect(vm.getNextPage).toHaveBeenCalled();
           done();
-        })
+        });
+      });
+    });
+    it('handles not scrolling if number of items less than elements in view', done => {
+      vm.items = [];
+      for(let i = 0; i < 5; ++i) {
+        vm.items.push('item' + i);
+      }
+      create.then(() => {
+        validateScroll(virtualRepeat, viewModel, () => {
+          expect(vm.getNextPage).not.toHaveBeenCalled();
+          done();
+        });
       });
     });
     it('passes the current index and location state', done => {


### PR DESCRIPTION
this._first becomes negative if this.items.length is smaller than
this.elementsInView. This negative index creates problems retrieving
data

This closes issue #111. Also the test 'VirtualRepeat Integration
infinite scroll handles getting next data set with small page size' is
changed because it wrongfully expected scrolling when the number of
items were less than the elements in the view.