### PR TITLE
fix(virtual-repeat): Changing the items to empty array from scrollable list

### DIFF
--- a/src/virtual-repeat.js
+++ b/src/virtual-repeat.js
@@ -113,6 +113,9 @@ export class VirtualRepeat extends AbstractRepeater {
 
   bind(bindingContext, overrideContext): void {
     this.scope = { bindingContext, overrideContext };
+    if (this._isAttached) {
+      this.itemsChanged();
+    }
   }
 
   call(context, changes): void {
@@ -454,7 +457,7 @@ export class VirtualRepeat extends AbstractRepeater {
   }
 
   _calcInitialHeights(itemsLength: number): void {
-    if (this._viewsLength > 0 && this._itemsLength === itemsLength || itemsLength <= 0) {
+    if (this._viewsLength > 0 && this._itemsLength === itemsLength || this._viewsLength > 0 && itemsLength < 0) {
       return;
     }
     this._hasCalculatedSizes = true;

--- a/test/virtual-repeat-integration.spec.js
+++ b/test/virtual-repeat-integration.spec.js
@@ -177,15 +177,15 @@ describe('VirtualRepeat Integration', () => {
   }
 
   function validateArrayChange(virtualRepeat, viewModel, done) {
-    viewModel.items = ['Foo B: 1', 'Foo B: 2', 'Foo B: 3', 'Foo B: 4', 'Foo B: 5'];
+    const createItems = (name, amount) => new Array(amount).map((v, index) => name + index);
+
+    viewModel.items = createItems('A', 4);
     nq(() => validateState(virtualRepeat, viewModel));
-    nq(() => {
-      let newArr = [];
-      for (let i = 0; i < 100; i++) {
-        newArr.push('Foo C: ' + i);
-      }
-      viewModel.items = newArr;
-    });
+    nq(() => viewModel.items = createItems('B', 0));
+    nq(() => validateState(virtualRepeat, viewModel));
+    nq(() => viewModel.items = createItems('C', 101));
+    nq(() => validateState(virtualRepeat, viewModel));
+    nq(() => viewModel.items = createItems('D', 0));
     nq(() => validateState(virtualRepeat, viewModel));
     nq(() => done());
   }


### PR DESCRIPTION
This PR should fix this issue #114
It's solving a bug when the virtual-repeat has enough items to allow user to scroll and these items is replaced with an empty array.
In this case the bottom placeholder height was not updated.