### PR TITLE
fix(VirtuaRepeat): don't calcuate size when not attached

### DIFF
--- a/src/virtual-repeat.js
+++ b/src/virtual-repeat.js
@@ -155,7 +155,7 @@ export class VirtualRepeat extends AbstractRepeater {
   itemsChanged(): void {
     this._unsubscribeCollection();
     // still bound?
-    if (!this.scope) {
+    if (!this.scope || !this._isAttached) {
       return;
     }
     let reducingItems = false;


### PR DESCRIPTION
When the attribute is still bound but no longer attached, trying to calculate size will cause error in `DomHelper`. This probably was overlook because working mechanism of `virtual-repeat` is different with `repeat`. Later when more configs are allowed, item height, for example, it can be continued without causing any trouble.