### PR TITLE
fix(virtual-repeat): Fixed construction of virtual repeat with empty array

### DIFF
--- a/src/virtual-repeat.js
+++ b/src/virtual-repeat.js
@@ -457,7 +457,7 @@ export class VirtualRepeat extends AbstractRepeater {
   }
 
   _calcInitialHeights(itemsLength: number): void {
-    if (this._viewsLength > 0 && this._itemsLength === itemsLength || this._viewsLength > 0 && itemsLength < 0) {
+    if (this._viewsLength > 0 && this._itemsLength === itemsLength || !this.viewCount()) {
       return;
     }
     this._hasCalculatedSizes = true;

--- a/test/virtual-repeat-integration.spec.js
+++ b/test/virtual-repeat-integration.spec.js
@@ -663,4 +663,35 @@ describe('VirtualRepeat Integration', () => {
         });
     });
   })
+
+  describe('initial setup', () => {
+    let component;
+    let virtualRepeat;
+    let viewModel;
+    let create;
+    let items;
+
+    beforeEach(() => {
+      items = [];
+      component = StageComponent
+        .withResources(['src/virtual-repeat'])
+        .inView(`<div style="height: ${itemHeight}px;" virtual-repeat.for="item of items">\${item}</div>`)
+        .boundTo({items: items});
+
+      create = component.create().then(() => {
+        virtualRepeat = component.sut;
+        viewModel = component.viewModel;
+      });
+    });
+
+    afterEach(() => {
+      component.cleanUp();
+    });
+
+    it('constructs with empty array', done => {
+      create
+        .then(() => validateState(virtualRepeat, viewModel))
+        .then(done);
+    });
+  });
 });


### PR DESCRIPTION
Now I'm validating if there is a view already added to the view slot to prevent useless calculation when the initial array is empty.