### PR TITLE
fix(TableStrategy): correctly determine first row

### DIFF
--- a/src/template-strategy.js
+++ b/src/template-strategy.js
@@ -56,9 +56,10 @@ export class TableStrategy {
 
   moveViewFirst(view: View, topBuffer: Element): void {
     const tbody = this._getTbodyElement(topBuffer.nextSibling);
-    const tr = tbody.firstChild;
-    const firstElement = DOM.nextElementSibling(tr);
-    insertBeforeNode(view, firstElement);
+    // Buffer for table doesn't reside inside the table
+    // so tbody first element child is the first child
+    // old behavior was to skip the first child, which was a bug
+    insertBeforeNode(view, tbody.firstElementChild);
   }
 
   moveViewLast(view: View, bottomBuffer: Element): void {


### PR DESCRIPTION
fixes #128 
fixes #84

From discussion in #46, I think buffer will never stay inside table, so I think this fix is fine. If it's to be changed, this needs to be revised.

About test, i'm not sure what to add

----

For folks who are affected by this, you have to temporarily modify the `node_modules/aurelia-ui-virtualization` as `TableStrategy` is not exported. Waiting for @EisenbergEffect @AStoker to review and release.

