### PR TITLE
fix(infinite-scroll-next): invoke get more if initial amount of item is small

### DIFF
--- a/sample/sample-v-ui-app/src/app.html
+++ b/sample/sample-v-ui-app/src/app.html
@@ -6,7 +6,7 @@
     <main as-element='router-view'></main>
   </div>
   <div
-    if.bind="virtualRepeat"
+    if.bind="window.virtualRepeat"
     class="bg-white border shadow-lg"
     style="position: fixed; bottom: 0; right: 0">
     <table>

--- a/sample/sample-v-ui-app/src/app.ts
+++ b/sample/sample-v-ui-app/src/app.ts
@@ -24,6 +24,12 @@ export class App {
         moduleId: PLATFORM.moduleName('./issue-129/sub-app'),
         nav: 3,
         title: 'Issue 129'
+      },
+      {
+        route: 'issue-102',
+        moduleId: PLATFORM.moduleName('./issue-102/sub-app'),
+        nav: 4,
+        title: 'Issue 102'
       }
     ]);
 
@@ -31,13 +37,5 @@ export class App {
     window['app'] = this;
   }
 
-  bind() {
-    this.check();
-  }
-
-  check() {
-    setInterval(() => {
-      this.virtualRepeat = window['virtualRepeat'];
-    }, 1500);
-  }
+  window = window;
 }

--- a/sample/sample-v-ui-app/src/app.ts
+++ b/sample/sample-v-ui-app/src/app.ts
@@ -10,14 +10,20 @@ export class App {
       {
         route: ['', 'phone-list'],
         moduleId: PLATFORM.moduleName('./phone-list'),
-        nav: true,
+        nav: 1,
         title: 'Contacts'
       },
       {
         route: 'issue-138',
         moduleId: PLATFORM.moduleName('./issue-138/sub-app'),
-        nav: true,
+        nav: 2,
         title: 'Issue 138'
+      },
+      {
+        route: 'issue-129',
+        moduleId: PLATFORM.moduleName('./issue-129/sub-app'),
+        nav: 3,
+        title: 'Issue 129'
       }
     ]);
 

--- a/sample/sample-v-ui-app/src/issue-102/sub-app.html
+++ b/sample/sample-v-ui-app/src/issue-102/sub-app.html
@@ -1,0 +1,27 @@
+<template>
+  <div class="">
+    <div class="d-flex justify-content-around">
+      <table class="table table-striped table-sm">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr virtual-repeat.for="person of people" infinite-scroll-next.call="push30($scrollContext)">
+            <td>${$index}</td>
+            <td>${person.fname}</td>
+            <td>${person.lname}</td>
+            <td>
+              <button type="button" class="btn btn-link"><i class="far fa-edit"></i></button>
+              <button type="button" class="btn btn-link"><i class="far fa-trash-alt"></i></button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>

--- a/sample/sample-v-ui-app/src/issue-102/sub-app.ts
+++ b/sample/sample-v-ui-app/src/issue-102/sub-app.ts
@@ -1,0 +1,47 @@
+interface IScrollContext {
+  isAtTop: boolean;
+  isAtBottom: boolean;
+  topIndex: number;
+}
+
+export interface Person {
+  fname: string;
+  lname: string;
+}
+
+const fNames = [
+  // tslint:disable-next-line:max-line-length
+  'Ford', 'Arthur', 'Trillian', 'Sneezy', 'Sleepy', 'Dopey', 'Doc', 'Happy', 'Bashful', 'Grumpy', 'Mufasa', 'Sarabi', 'Simba', 'Nala', 'Kiara', 'Kovu', 'Timon', 'Pumbaa', 'Rafiki', 'Shenzi'
+];
+const lNames = [
+  // tslint:disable-next-line:max-line-length
+  'Prefect', 'Dent', 'Astra', 'Adams', 'Baker', 'Clark', 'Davis', 'Evans', 'Frank', 'Ghosh', 'Hills', 'Irwin', 'Jones', 'Klein', 'Lopez', 'Mason', 'Nalty', 'Ochoa', 'Patel', 'Quinn', 'Reily', 'Smith', 'Trott', 'Usman', 'Valdo', 'White', 'Xiang', 'Yakub', 'Zafar'
+];
+export class App {
+  private people: Person[];
+
+  constructor() {
+    this.people = [
+      { fname: fNames[0], lname: lNames[0] },
+      { fname: fNames[1], lname: lNames[1] },
+      { fname: fNames[2], lname: lNames[2] }
+    ];
+    this.push30(undefined, 0);
+  }
+
+  public push30(scrollContext?: IScrollContext, count = 30) {
+    console.log('Issue-102 getting more...');
+    // if (scrollContext) {
+    //   console.log('Issue-129 getting more:', JSON.stringify(scrollContext, undefined, 2));
+    // }
+    if (!scrollContext || scrollContext.isAtBottom) {
+      for (let i = 0; i < count; i++) {
+        this.people.push({
+          fname: fNames[Math.floor(Math.random() * fNames.length)],
+          lname: lNames[Math.floor(Math.random() * lNames.length)]
+        });
+      }
+    }
+    console.log('Population size:', this.people.length);
+  }
+}

--- a/sample/sample-v-ui-app/src/issue-129/sub-app.html
+++ b/sample/sample-v-ui-app/src/issue-129/sub-app.html
@@ -1,0 +1,27 @@
+<template>
+  <div class="">
+    <div class="d-flex justify-content-around">
+      <table class="table table-striped table-sm">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr virtual-repeat.for="person of people" infinite-scroll-next.call="push30($scrollContext)">
+            <td>${$index}</td>
+            <td>${person.fname}</td>
+            <td>${person.lname}</td>
+            <td>
+              <button type="button" class="btn btn-link"><i class="far fa-edit"></i></button>
+              <button type="button" class="btn btn-link"><i class="far fa-trash-alt"></i></button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>

--- a/sample/sample-v-ui-app/src/issue-129/sub-app.ts
+++ b/sample/sample-v-ui-app/src/issue-129/sub-app.ts
@@ -30,9 +30,10 @@ export class App {
   }
 
   public push30(scrollContext?: IScrollContext, count = 30) {
-    if (scrollContext) {
-      console.log('Issue-129 getting more:', JSON.stringify(scrollContext, undefined, 2));
-    }
+    console.log('Issue-129 getting more...');
+    // if (scrollContext) {
+    //   console.log('Issue-129 getting more:', JSON.stringify(scrollContext, undefined, 2));
+    // }
     if (!scrollContext || scrollContext.isAtBottom) {
       for (let i = 0; i < count; i++) {
         this.people.push({

--- a/sample/sample-v-ui-app/src/issue-129/sub-app.ts
+++ b/sample/sample-v-ui-app/src/issue-129/sub-app.ts
@@ -1,0 +1,46 @@
+interface IScrollContext {
+  isAtTop: boolean;
+  isAtBottom: boolean;
+  topIndex: number;
+}
+
+export interface Person {
+  fname: string;
+  lname: string;
+}
+
+const fNames = [
+  // tslint:disable-next-line:max-line-length
+  'Ford', 'Arthur', 'Trillian', 'Sneezy', 'Sleepy', 'Dopey', 'Doc', 'Happy', 'Bashful', 'Grumpy', 'Mufasa', 'Sarabi', 'Simba', 'Nala', 'Kiara', 'Kovu', 'Timon', 'Pumbaa', 'Rafiki', 'Shenzi'
+];
+const lNames = [
+  // tslint:disable-next-line:max-line-length
+  'Prefect', 'Dent', 'Astra', 'Adams', 'Baker', 'Clark', 'Davis', 'Evans', 'Frank', 'Ghosh', 'Hills', 'Irwin', 'Jones', 'Klein', 'Lopez', 'Mason', 'Nalty', 'Ochoa', 'Patel', 'Quinn', 'Reily', 'Smith', 'Trott', 'Usman', 'Valdo', 'White', 'Xiang', 'Yakub', 'Zafar'
+];
+export class App {
+  private people: Person[];
+
+  constructor() {
+    this.people = [
+      { fname: fNames[0], lname: lNames[0] },
+      { fname: fNames[1], lname: lNames[1] },
+      { fname: fNames[2], lname: lNames[2] }
+    ];
+    this.push30(undefined, 5);
+  }
+
+  public push30(scrollContext?: IScrollContext, count = 30) {
+    if (scrollContext) {
+      console.log('Issue-129 getting more:', JSON.stringify(scrollContext, undefined, 2));
+    }
+    if (!scrollContext || scrollContext.isAtBottom) {
+      for (let i = 0; i < count; i++) {
+        this.people.push({
+          fname: fNames[Math.floor(Math.random() * fNames.length)],
+          lname: lNames[Math.floor(Math.random() * lNames.length)]
+        });
+      }
+    }
+    console.log('Population size:', this.people.length);
+  }
+}

--- a/sample/sample-v-ui-app/webpack.config.js
+++ b/sample/sample-v-ui-app/webpack.config.js
@@ -57,9 +57,7 @@ module.exports = {
     ]
   },
   plugins: [
-    new AureliaPlugin({
-      dist: 'es2015'
-    }),
+    new AureliaPlugin(),
     // Standard plugin to build index.html
     new HtmlWebpackPlugin({
       template: 'index.ejs'

--- a/sample/sample-v-ui-app/webpack.config.js
+++ b/sample/sample-v-ui-app/webpack.config.js
@@ -57,7 +57,9 @@ module.exports = {
     ]
   },
   plugins: [
-    new AureliaPlugin(),
+    new AureliaPlugin({
+      dist: 'es2015'
+    }),
     // Standard plugin to build index.html
     new HtmlWebpackPlugin({
       template: 'index.ejs'

--- a/src/aurelia-ui-virtualization.ts
+++ b/src/aurelia-ui-virtualization.ts
@@ -12,3 +12,7 @@ export {
   VirtualRepeat,
   InfiniteScrollNext
 };
+
+export {
+  IScrollNextScrollContext
+} from './interfaces';

--- a/src/infinite-scroll-next.ts
+++ b/src/infinite-scroll-next.ts
@@ -1,5 +1,3 @@
-import { OverrideContext, Scope } from 'aurelia-binding';
-
 // Placeholder attribute to prohibit use of this attribute name in other places
 export class InfiniteScrollNext {
 
@@ -9,16 +7,5 @@ export class InfiniteScrollNext {
       type: 'attribute',
       name: 'infinite-scroll-next'
     };
-  }
-
-  /**@internal */
-  scope: Scope;
-
-  bind(bindingContext: any, overrideContext: OverrideContext): void {
-    this.scope = { bindingContext, overrideContext };
-  }
-
-  unbind() {
-    this.scope = undefined;
   }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -55,13 +55,25 @@ export interface IVirtualRepeatStrategy extends RepeatStrategy {
 
 export interface IVirtualRepeat extends Repeat {
 
-  /**@internal */ _first: number;
+  /**
+   * @internal
+   * First view index, for proper follow up calculations
+   */
+  _first: number;
 
-  /**@internal */ _previousFirst: number;
+  /**
+   * @internal
+   * Preview first view index, for proper determination of delta
+   */
+  _previousFirst: number;
 
   /**@internal */ _viewsLength: number;
 
-  /**@internal */ _lastRebind: number;
+  /**
+   * @internal
+   * Last rebound view index, for determining rendered range
+   */
+  _lastRebind: number;
 
   /**@internal */ _topBufferHeight: number;
 
@@ -89,6 +101,7 @@ export interface IVirtualRepeat extends Repeat {
 
   /**@internal */ viewSlot: ViewSlot & { children: IView[] };
 
+  items: any[];
   itemHeight: number;
 
   strategy: IVirtualRepeatStrategy;
@@ -141,3 +154,19 @@ export interface ITemplateStrategy {
  * Override `bindingContext` and `overrideContext` on `View` interface
  */
 export type IView = View & Scope;
+
+// export const enum IVirtualRepeatState {
+//   isAtTop = 0b0_000000_000,
+//   isLastIndex = 0b0_000000_000,
+//   scrollingDown = 0b0_000000_000,
+//   scrollingUp = 0b0_000000_000,
+//   switchedDirection = 0b0_000000_000,
+//   isAttached = 0b0_000000_000,
+//   ticking = 0b0_000000_000,
+//   fixedHeightContainer = 0b0_000000_000,
+//   hasCalculatedSizes = 0b0_000000_000,
+//   calledGetMore = 0b0_000000_000,
+//   skipNextScrollHandle = 0b0_000000_000,
+//   handlingMutations = 0b0_000000_000,
+//   isScrolling = 0b0_000000_000
+// }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,6 +3,12 @@ import { ViewSlot, View, ViewFactory, BoundViewFactory, Controller } from 'aurel
 import { Scope, Binding, OverrideContext } from 'aurelia-binding';
 import { TaskQueue } from 'aurelia-task-queue';
 
+export interface IScrollNextScrollContext {
+  topIndex: number;
+  isAtBottom: boolean;
+  isAtTop: boolean;
+}
+
 /**@internal */
 declare module 'aurelia-binding' {
   interface ObserverLocator {
@@ -11,11 +17,7 @@ declare module 'aurelia-binding' {
 
   interface OverrideContext {
     $index: number;
-    $scrollContext: {
-      topIndex: number;
-      isAtBottom: boolean;
-      isAtTop: boolean;
-    };
+    $scrollContext: IScrollNextScrollContext;
     $first: boolean;
     $last: boolean;
     $middle: boolean;

--- a/src/virtual-repeat.ts
+++ b/src/virtual-repeat.ts
@@ -225,7 +225,6 @@ export class VirtualRepeat extends AbstractRepeater implements IVirtualRepeat {
   /**@override */
   bind(bindingContext: any, overrideContext: OverrideContext): void {
     this.scope = { bindingContext, overrideContext };
-    window['virtualRepeat'] = this;
   }
 
   /**@override */

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -67,7 +67,10 @@ export function validateScrolledState(virtualRepeat: VirtualRepeat, viewModel: a
   let topBufferHeight = virtualRepeat.topBuffer.getBoundingClientRect().height;
   let bottomBufferHeight = virtualRepeat.bottomBuffer.getBoundingClientRect().height;
   let renderedItemsHeight = views.length * itemHeight;
-  expect(topBufferHeight + renderedItemsHeight + bottomBufferHeight).toBe(expectedHeight);
+  expect(topBufferHeight + renderedItemsHeight + bottomBufferHeight).toBe(
+    expectedHeight,
+    `Top buffer (${topBufferHeight}) + items height (${renderedItemsHeight}) + bottom buffer (${bottomBufferHeight}) should have been correct`
+  );
 
   if (viewModel.items.length > views.length) {
     expect(topBufferHeight + bottomBufferHeight).toBeGreaterThan(0);
@@ -90,4 +93,22 @@ export function validateScrolledState(virtualRepeat: VirtualRepeat, viewModel: a
     expect(overrideContext.$odd).toBe(!even);
     expect(overrideContext.$even).toBe(even);
   }
+}
+
+/**
+ * Manually dispatch a scroll event and validate scrolled state of virtual repeat
+ *
+ * Programatically set `scrollTop` of element specified with `elementSelector` query string
+ * (or `#scrollContainer` by default) to be equal with its `scrollHeight`
+ */
+export function validateScroll(virtualRepeat: VirtualRepeat, viewModel: any, itemHeight: number, element: Element, done: Function): void {
+  let event = new Event('scroll');
+  element.scrollTop = element.scrollHeight;
+  element.dispatchEvent(event);
+  window.setTimeout(() => {
+    window.requestAnimationFrame(() => {
+      validateScrolledState(virtualRepeat, viewModel, itemHeight);
+      done();
+    });
+  });
 }

--- a/test/virtual-repeat-integration.spec.ts
+++ b/test/virtual-repeat-integration.spec.ts
@@ -549,6 +549,11 @@ describe('VirtualRepeat Integration', () => {
         });
       });
     });
+    // The following test used to pass because there was no getMore() invoked during initialization
+    // so `validateScroll()` would not have been able to trigger all flow within _handleScroll of VirtualRepeat instance
+    // with the commit to fix issue 129, it starts to have more item and thus, scrollContainer has real scrollbar
+    // making synthesized scroll event in `validateScroll` work, resulting in failed test
+    // kept but commented out for history reason
     // it('handles not scrolling if number of items less than elements in view', done => {
     //   vm.items = [];
     //   for (let i = 0; i < 5; ++i) {


### PR DESCRIPTION
The existing logic doesn't account for initialization scenario when it needs to determine whether scroll next should be invoked. Add some logic in `attached()` to handle this.

demo app at https://dist-vgkbrvzizc.now.sh/#/issue-129 (initial items count is 5) 

fix #129
fix #102 (demo at https://dist-lvubilwhjh.now.sh/#/issue-102)

@EisenbergEffect @AStoker 