### PR TITLE
refactor(repeat): better handle scrolling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "tslint.autoFixOnSave": true
 }

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ export class MyVirtualList {
 }
 ```
 
-With a surrounding fixed height container with overflow scroll. Note that `overflow: scroll` styling needs to be inline on the elemenet.
+With a surrounding fixed height container with overflow scroll. Note that `overflow: scroll` styling is inlined on the elemenet. It can also be applied from CSS.
 
 ```html
 <template>
@@ -92,17 +92,17 @@ If you are running the plugin in the `skeleton-naviagion` project, make sure to 
     ${$index} ${item}
   </div>
 </template>
-```  
+```
 ```javascript
 export class MyVirtualList {
-    items = ['Foo', 'Bar', 'Baz'];
-    getMore(topIndex, isAtBottom, isAtTop) {
-        for(let i = 0; i < 100; ++i) {
-            this.items.push('item' + i);
-        }
+  items = ['Foo', 'Bar', 'Baz'];
+  getMore(topIndex, isAtBottom, isAtTop) {
+    for(let i = 0; i < 100; ++i) {
+      this.items.push('item' + i);
     }
+  }
 }
-```  
+```
 
 Or to use an expression, use `.call` as shown below.
 ```html
@@ -111,23 +111,24 @@ Or to use an expression, use `.call` as shown below.
     ${$index} ${item}
   </div>
 </template>
-```  
+```
 ```javascript
 export class MyVirtualList {
-    items = ['Foo', 'Bar', 'Baz'];
-    getMore(scrollContext) {
-        for(let i = 0; i < 100; ++i) {
-            this.items.push('item' + i);
-        }
+  items = ['Foo', 'Bar', 'Baz'];
+  getMore(scrollContext) {
+    for(let i = 0; i < 100; ++i) {
+      this.items.push('item' + i);
     }
+  }
 }
-```  
+```
 
-The `infinite-scroll-next` attribute can accept a function, a promise, or a function that returns a promise.  
-The bound function will be called when the scroll container has reached a point where there are no more items to move into the DOM (i.e. when it reaches the end of a list, either from the top or the bottom).  
-There are three parameters that are passed to the function (`getMore(topIndex, isAtBottom, isAtTop)`) which helps determine the behavior or amount of items to get during scrolling.    
-1. `topIndex` - A integer value that represents the current item that exists at the top of the rendered items in the DOM.  
-2. `isAtBottom` - A boolean value that indicates whether the list has been scrolled to the bottom of the items list.  
+The `infinite-scroll-next` attribute can accept a function, a promise, or a function that returns a promise.
+The bound function will be called when the scroll container has reached a point where there are no more items to move into the DOM (i.e. when it reaches the end of a list, either from the top or the bottom).
+
+There are three parameters that are passed to the function (`getMore(topIndex, isAtBottom, isAtTop)`) which helps determine the behavior or amount of items to get during scrolling.
+1. `topIndex` - A integer value that represents the current item that exists at the top of the rendered items in the DOM.
+2. `isAtBottom` - A boolean value that indicates whether the list has been scrolled to the bottom of the items list.
 3. `isAtTop` - A boolean value that indicates whether the list has been scrolled to the top of the items list.
 
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "dev": "cd sample/sample-v-ui-app && npm run dev",
+    "build:demo": "cd sample/sample-v-ui-app && npm run build:demo",
     "prebuild": "npm run rimraf",
     "build": "rollup -c",
     "changelog": "node build/changelog.js",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "type": "git",
     "url": "http://github.com/aurelia/ui-virtualization"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "dev": "cd sample/sample-v-ui-app && npm run dev",
     "build:demo": "cd sample/sample-v-ui-app && npm run build:demo",

--- a/sample/sample-v-ui-app/package.json
+++ b/sample/sample-v-ui-app/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "dev": "webpack-dev-server",
+    "dev": "webpack-dev-server --open",
     "prebuild": "npm run rimraf",
     "build": "webpack",
     "prebuild:watch": "npm run rimraf",

--- a/sample/sample-v-ui-app/src/app.html
+++ b/sample/sample-v-ui-app/src/app.html
@@ -1,6 +1,7 @@
 <template>
   <require from='./nav-bar'></require>
   <require from='./checkbox.html'></require>
+  <let minimized-monitor.bind="true"></let>
   <div class="container">
     <nav-bar router.bind='router'></nav-bar>
     <main as-element='router-view'></main>

--- a/sample/sample-v-ui-app/src/app.html
+++ b/sample/sample-v-ui-app/src/app.html
@@ -18,7 +18,7 @@
     style="position: fixed; bottom: 0; right: 0; max-height: 80vh;">
     <let
       virtual-repeat.bind='window.virtualRepeat'
-      view-count-same-max-views-require.bind="virtualRepeat.viewSlot.children.length === (virtualRepeat.elementsInView * 2)"></let>
+      view-count-same-max-views-required.bind="virtualRepeat.viewSlot.children.length === (virtualRepeat.minViewsRequired * 2)"></let>
     <button
       class="btn btn-sm btn-block btn-info flex-shrink-0"
       click.trigger="minimizedMonitor = true">Minimize monitor</button>
@@ -42,17 +42,17 @@
         </tr>
         <tr>
           <td>Active views count</td>
-          <td class="table-${viewCountSameMaxViewsRequire ? 'success' : 'warning'}">${virtualRepeat.viewSlot.children.length}</td>
+          <td class="table-${viewCountSameMaxViewsRequired ? 'success' : 'warning'}">${virtualRepeat.viewSlot.children.length}</td>
         </tr>
         <tr>
-          <td>Max views</td>
-          <td class="table-${viewCountSameMaxViewsRequire ? 'success' : 'warning'}">${virtualRepeat.elementsInView * 2}</td>
+          <td>Max views required</td>
+          <td class="table-${viewCountSameMaxViewsRequired ? 'success' : 'warning'}">${virtualRepeat.minViewsRequired * 2}</td>
         </tr>
         <!-- <tr>
           <td>Last Rebind</td><td>${virtualRepeat._lastRebind}</td> -->
         <tr>
-          <td>Elements In view</td>
-          <td>${virtualRepeat.elementsInView}</td>
+          <td>Min Views Required</td>
+          <td>${virtualRepeat.minViewsRequired}</td>
         </tr>
         <tr>
           <td>First</td><td>${virtualRepeat._first}</td>

--- a/sample/sample-v-ui-app/src/app.html
+++ b/sample/sample-v-ui-app/src/app.html
@@ -18,7 +18,7 @@
     style="position: fixed; bottom: 0; right: 0; max-height: 80vh;">
     <let
       virtual-repeat.bind='window.virtualRepeat'
-      view-count-same-max-views-require.bind="virtualRepeat.viewSlot.children.length === virtualRepeat._viewsLength"></let>
+      view-count-same-max-views-require.bind="virtualRepeat.viewSlot.children.length === (virtualRepeat.elementsInView * 2)"></let>
     <button
       class="btn btn-sm btn-block btn-info flex-shrink-0"
       click.trigger="minimizedMonitor = true">Minimize monitor</button>
@@ -41,23 +41,23 @@
           <td>${virtualRepeat.items.length * virtualRepeat.itemHeight}</td>
         </tr>
         <tr>
-          <td>Total views count</td>
+          <td>Active views count</td>
           <td class="table-${viewCountSameMaxViewsRequire ? 'success' : 'warning'}">${virtualRepeat.viewSlot.children.length}</td>
         </tr>
         <tr>
-          <td>Real views count</td>
-          <td class="table-${viewCountSameMaxViewsRequire ? 'success' : 'warning'}">${virtualRepeat._viewsLength}</td>
+          <td>Max views</td>
+          <td class="table-${viewCountSameMaxViewsRequire ? 'success' : 'warning'}">${virtualRepeat.elementsInView * 2}</td>
         </tr>
-        <tr>
-          <td>Last Rebind</td><td>${virtualRepeat._lastRebind}</td>
+        <!-- <tr>
+          <td>Last Rebind</td><td>${virtualRepeat._lastRebind}</td> -->
         <tr>
           <td>Elements In view</td>
           <td>${virtualRepeat.elementsInView}</td>
         </tr>
         <tr>
           <td>First</td><td>${virtualRepeat._first}</td>
-        <tr>
-          <td>Previous First</td><td>${virtualRepeat._previousFirst}</td>
+        <!-- <tr>
+          <td>Previous First</td><td>${virtualRepeat._previousFirst}</td> -->
         <tr>
           <td>Top Buffer height</td>
           <td>${virtualRepeat._topBufferHeight}</td>
@@ -70,21 +70,21 @@
           <td>Distance to top</td>
           <td>${virtualRepeat.distanceToTop}</td>
         </tr>
-        <tr>
+        <!-- <tr>
           <td>Scrolling Down</td>
           <td><checkbox checked.bind=virtualRepeat._scrollingDown></checkbox></td>
-        </tr>
-        <tr>
+        </tr> -->
+        <!-- <tr>
           <td>Scrolling Up</td>
           <td><checkbox checked.bind=virtualRepeat._scrollingUp></checkbox></td>
-        </tr>
-        <tr>
+        </tr> -->
+        <!-- <tr>
           <td>Is First or last</td>
-          <td><checkbox checked.bind=virtualRepeat._isAtFirstOrLastIndex></checkbox></td>
-        <tr>
+          <td><checkbox checked.bind=virtualRepeat._isAtFirstOrLastIndex></checkbox></td> -->
+        <!-- <tr>
           <td>Switched Direction</td>
           <td><checkbox checked.bind=virtualRepeat._switchedDirection></checkbox></td>
-        </tr>
+        </tr> -->
         <tr>
           <td>Is Attached</td>
           <td><checkbox checked.bind=virtualRepeat._isAttached></checkbox></td>
@@ -95,16 +95,17 @@
         <tr>
           <td>Fixed height Container</td>
           <td><checkbox checked.bind=virtualRepeat._fixedHeightContainer></checkbox></td>
-        <tr>
-          <td>Has Calculated Size</td><td><checkbox checked.bind=virtualRepeat._hasCalculatedSizes></checkbox></td>
-        <tr>
+        <!-- <tr>
+          <td>Has Calculated Size</td>
+          <td><checkbox checked.bind=virtualRepeat._hasCalculatedSizes></checkbox></td> -->
+        <!-- <tr>
           <td>Is At top</td>
           <td><checkbox checked.bind=virtualRepeat._isAtTop></checkbox></td>
-        </tr>
-        <tr>
+        </tr> -->
+        <!-- <tr>
           <td>Is Last Index</td>
           <td><checkbox checked.bind=virtualRepeat.isLastIndex></checkbox></td>
-        </tr>
+        </tr> -->
         <tr>
           <td>Called Get More</td>
           <td><checkbox checked.bind=virtualRepeat._calledGetMore></checkbox></td>
@@ -117,10 +118,10 @@
           <td>Handling Mutation</td>
           <td><checkbox checked.bind=virtualRepeat._handlingMutations></checkbox></td>
         </tr>
-        <tr>
+        <!-- <tr>
           <td>Is Scrolling</td>
           <td><checkbox checked.bind=virtualRepeat._isScrolling></checkbox></td>
-        </tr>
+        </tr> -->
       </table>
     </div>
   </div>

--- a/sample/sample-v-ui-app/src/app.html
+++ b/sample/sample-v-ui-app/src/app.html
@@ -17,8 +17,7 @@
     class="bg-white border shadow-lg d-flex flex-column"
     style="position: fixed; bottom: 0; right: 0; max-height: 80vh;">
     <let
-      virtual-repeat.bind='window.virtualRepeat'
-      view-count-same-max-views-required.bind="virtualRepeat.viewSlot.children.length === (virtualRepeat.minViewsRequired * 2)"></let>
+      virtual-repeat.bind='window.virtualRepeat'></let>
     <button
       class="btn btn-sm btn-block btn-info flex-shrink-0"
       click.trigger="minimizedMonitor = true">Minimize monitor</button>
@@ -42,11 +41,11 @@
         </tr>
         <tr>
           <td>Active views count</td>
-          <td class="table-${viewCountSameMaxViewsRequired ? 'success' : 'warning'}">${virtualRepeat.viewSlot.children.length}</td>
+          <td class="table-${virtualRepeat.viewSlot.children.length === virtualRepeat.minViewsRequired * 2 ? 'success' : 'warning'}">${virtualRepeat.viewSlot.children.length}</td>
         </tr>
         <tr>
           <td>Max views required</td>
-          <td class="table-${viewCountSameMaxViewsRequired ? 'success' : 'warning'}">${virtualRepeat.minViewsRequired * 2}</td>
+          <td class="table-${virtualRepeat.viewSlot.children.length === virtualRepeat.minViewsRequired * 2 ? 'success' : 'warning'}">${virtualRepeat.minViewsRequired * 2}</td>
         </tr>
         <!-- <tr>
           <td>Last Rebind</td><td>${virtualRepeat._lastRebind}</td> -->
@@ -55,16 +54,16 @@
           <td>${virtualRepeat.minViewsRequired}</td>
         </tr>
         <tr>
-          <td>First</td><td>${virtualRepeat._first}</td>
+          <td>First</td><td>${virtualRepeat.$first}</td>
         <!-- <tr>
           <td>Previous First</td><td>${virtualRepeat._previousFirst}</td> -->
         <tr>
           <td>Top Buffer height</td>
-          <td>${virtualRepeat._topBufferHeight}</td>
+          <td>${virtualRepeat.topBufferHeight}</td>
         </tr>
         <tr>
           <td>Bottom Buffer height</td>
-          <td>${virtualRepeat._bottomBufferHeight}</td>
+          <td>${virtualRepeat.bottomBufferHeight}</td>
         </tr>
         <tr>
           <td>Distance to top</td>

--- a/sample/sample-v-ui-app/src/app.ts
+++ b/sample/sample-v-ui-app/src/app.ts
@@ -58,7 +58,7 @@ export class App {
       // {
       //   route: 'issue-117',
       //   moduleId: PLATFORM.moduleName('./issue-117/sub-app'),
-      //   nav: 7,
+      //   nav: true,
       //   title: 'Issue 117'
       // },
       {

--- a/sample/sample-v-ui-app/src/app.ts
+++ b/sample/sample-v-ui-app/src/app.ts
@@ -55,12 +55,12 @@ export class App {
         nav: true,
         title: 'Issue 114'
       },
-      // {
-      //   route: 'issue-117',
-      //   moduleId: PLATFORM.moduleName('./issue-117/sub-app'),
-      //   nav: true,
-      //   title: 'Issue 117'
-      // },
+      {
+        route: 'issue-117',
+        moduleId: PLATFORM.moduleName('./issue-117/sub-app'),
+        nav: true,
+        title: 'Issue 117'
+      },
       {
         route: 'non-issues',
         moduleId: PLATFORM.moduleName('./non-issues/sub-app'),

--- a/sample/sample-v-ui-app/src/app.ts
+++ b/sample/sample-v-ui-app/src/app.ts
@@ -1,5 +1,5 @@
 import { Router, RouterConfiguration } from 'aurelia-router';
-import { PLATFORM } from 'aurelia-framework';
+import { PLATFORM, View } from 'aurelia-framework';
 
 export class App {
   router: Router;
@@ -77,6 +77,10 @@ export class App {
 
     this.router = router;
     window['app'] = this;
+  }
+
+  created(_: any, view: View) {
+    window['view'] = view;
   }
 
   window = window;

--- a/sample/sample-v-ui-app/src/contrived/multiple-repeat-document/sub-app.html
+++ b/sample/sample-v-ui-app/src/contrived/multiple-repeat-document/sub-app.html
@@ -1,0 +1,46 @@
+<template>
+  <div ref="parentElement">
+    <h1 style="color: #fff; background-color:#ed2b88">First List</h1>
+    <div virtual-repeat.for="item of objectArray" class="contact-list-item ${item.name}">
+      <div class="contact-item">
+        <div class="avatar" click.delegate="click()" css="background-color: ${item.color}">
+          ${item.firstLetter}
+        </div>
+        <div class="name">${$index} ${item.name} </div>
+        <div class="content">
+          <strong>Phone:</strong> ${item.phone} <br>
+          <strong>Country:</strong> ${item.country} <br> </div>
+      </div>
+    </div>
+    <h1 class="py-4" style="color: #fff; background-color:#ed2b88">Second List</h1>
+    <div virtual-repeat.for="item of objectArray" class="contact-list-item ${item.name}">
+      <div class="contact-item">
+        <div class="avatar" click.delegate="click()" css="background-color: ${item.color}">${item.firstLetter}
+        </div>
+        <div class="name"> ${$index} ${item.name} </div>
+        <div class="content">
+          <strong>Phone:</strong> ${item.phone} <br>
+          <strong>Country:</strong> ${item.country} <br>
+        </div>
+      </div>
+    </div>
+    <h1 class="py-4" style="color: #fff; background-color:#ed2b88">Third List</h1>
+    <div virtual-repeat.for="item of objectArray" class="contact-list-item ${item.name}">
+      <div class="contact-item">
+        <div class="avatar" click.delegate="click()" css="background-color: ${item.color}">${item.firstLetter}
+        </div>
+        <div class="name">${$index} ${item.name} </div>
+        <div class="content">
+          <strong>Phone:</strong> ${item.phone} <br>
+          <strong>Country:</strong> ${item.country} <br>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="bg-white shadow-lg p-2 border"
+    style="position: fixed; bottom: 0; right: 250px">
+    Item Count: ${itemsCount}<br>
+    DOM elements Count: ${childrenCount - 3}<br>
+  </div>
+</template>

--- a/sample/sample-v-ui-app/src/contrived/multiple-repeat-document/sub-app.ts
+++ b/sample/sample-v-ui-app/src/contrived/multiple-repeat-document/sub-app.ts
@@ -1,0 +1,76 @@
+declare const faker: any;
+
+interface IDemoItem {
+  firstLetter: string;
+  name: string;
+  color: string;
+  phone: string;
+  country: string;
+}
+
+
+export class MultipleListsDemoRoute {
+
+  objectArray: IDemoItem[];
+  numberOfItems: number;
+  isSelected: boolean;
+
+  readonly parentElement: Element;
+
+  constructor() {
+    this.objectArray = [];
+    this.numberOfItems = 1e4;
+    this.isSelected = false;
+  }
+
+  createItem(): IDemoItem {
+    let b = faker.name.findName();
+    return {
+      firstLetter: b.charAt(0),
+      name: b,
+      color: faker.internet.color(),
+      phone: faker.phone.phoneNumber(),
+      country: faker.address.country()
+    };
+  }
+
+  activate() {
+    for (let b = 0; b < this.numberOfItems; ++b) {
+      this.objectArray.push(this.createItem());
+    }
+  }
+
+  addItems(count: number) {
+    for (let i = 0; count > i; ++i) {
+      this.objectArray.push(this.createItem());
+    }
+  }
+
+  addItemFirst() {
+    this.objectArray.unshift(this.createItem());
+  }
+
+  removeItems(count: number) {
+    this.objectArray.splice(0, count);
+  }
+
+  addItemLast() {
+    this.objectArray.push(this.createItem());
+  }
+
+  removeLast() {
+    this.objectArray.pop();
+  }
+
+  get itemsCount(): number {
+    return this.objectArray.length;
+  }
+
+  get childrenCount(): number {
+    return this.parentElement ? this.parentElement.children.length : 0;
+  }
+
+  click(item: IDemoItem) {
+    console.log('clicked on', item);
+  }
+}

--- a/sample/sample-v-ui-app/src/contrived/sub-app.html
+++ b/sample/sample-v-ui-app/src/contrived/sub-app.html
@@ -3,7 +3,7 @@
     <a
       repeat.for="nav of router.navigation"
       href.bind='nav.href'
-      class='btn btn-sm btn-primary text-white mr-2'>${nav.title}</a>
+      class="btn btn-sm btn-${nav.isActive ? '' : 'outline-'}primary mr-2">${nav.title}</a>
   </div>
   <router-view></router-view>
 </template>

--- a/sample/sample-v-ui-app/src/contrived/sub-app.ts
+++ b/sample/sample-v-ui-app/src/contrived/sub-app.ts
@@ -12,7 +12,7 @@ export class ContrivedExamplesApp {
         route: ['', 'empty-init'],
         moduleId: PLATFORM.moduleName('./empty-init/empty-init'),
         nav: true,
-        title: 'Empty init collection + Infinite get-more'
+        title: 'Empty init collection'
       },
       {
         name: 'contrived.main2',
@@ -20,6 +20,12 @@ export class ContrivedExamplesApp {
         moduleId: PLATFORM.moduleName('./empty-init-clone-array/empty-init'),
         nav: true,
         title: 'Empty init collection + clone array value converter'
+      },
+      {
+        route: 'multiple-lists-document',
+        moduleId: PLATFORM.moduleName('./multiple-repeat-document/sub-app'),
+        nav: true,
+        title: 'Multiple lists on document'
       }
     ]).mapUnknownRoutes({
       redirect: '',

--- a/sample/sample-v-ui-app/src/issue-117/sub-app.html
+++ b/sample/sample-v-ui-app/src/issue-117/sub-app.html
@@ -1,6 +1,39 @@
 <template>
-  <div class="">
-    <div class="d-flex justify-content-around">
+  <!-- start with fixed height container -->
+  <let mode.bind='2'></let>
+  <div>
+    <button
+      class="btn btn-${mode !== 2 ? '' : 'outline-'}primary btn-sm"
+      click.trigger="mode = 1">Full page scrolling</button>
+    <button
+      class="btn btn-${mode === 2 ? '' : 'outline-'}primary btn-sm"
+      click.trigger="mode = 2">Fixed height container</button>
+  </div>
+  <div if.bind="mode !== 2">
+    <table class="table table-striped table-sm">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr virtual-repeat.for="person of people" infinite-scroll-next.call="push30($scrollContext)">
+          <td>${$index}</td>
+          <td>${person.fname}</td>
+          <td>${person.lname}</td>
+          <td>
+            <button type="button" class="btn btn-link"><i class="far fa-edit"></i></button>
+            <button type="button" class="btn btn-link"><i class="far fa-trash-alt"></i></button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div else>
+    <div class="scrollbar-y" style="height: 600px;">
       <table class="table table-striped table-sm">
         <thead>
           <tr>

--- a/sample/sample-v-ui-app/src/issue-117/sub-app.html
+++ b/sample/sample-v-ui-app/src/issue-117/sub-app.html
@@ -20,7 +20,10 @@
         </tr>
       </thead>
       <tbody>
-        <tr virtual-repeat.for="person of people" infinite-scroll-next.call="push30($scrollContext)">
+        <tr
+          virtual-repeat.for="person of people"
+          infinite-scroll-next.call="push30($scrollContext)"
+          class="i-${$index}">
           <td>${$index}</td>
           <td>${person.fname}</td>
           <td>${person.lname}</td>
@@ -44,7 +47,10 @@
           </tr>
         </thead>
         <tbody>
-          <tr virtual-repeat.for="person of people" infinite-scroll-next.call="push30($scrollContext)">
+          <tr
+            virtual-repeat.for="person of people"
+            infinite-scroll-next.call="push30($scrollContext)"
+            class="i-${$index}">
             <td>${$index}</td>
             <td>${person.fname}</td>
             <td>${person.lname}</td>

--- a/sample/sample-v-ui-app/src/issue-117/sub-app.html
+++ b/sample/sample-v-ui-app/src/issue-117/sub-app.html
@@ -1,15 +1,18 @@
 <template>
   <!-- start with fixed height container -->
   <let mode.bind='2'></let>
-  <div>
+  <div scrollbar='x' class='px-1'>
     <button
-      class="btn btn-${mode !== 2 ? '' : 'outline-'}primary btn-sm"
+      class="btn btn-${mode === 1 ? '' : 'outline-'}primary btn-sm"
       click.trigger="mode = 1">Full page scrolling</button>
     <button
       class="btn btn-${mode === 2 ? '' : 'outline-'}primary btn-sm"
       click.trigger="mode = 2">Fixed height container</button>
+    <button
+      class="btn btn-${mode === 3 ? '' : 'outline-'}primary btn-sm"
+      click.trigger="mode = 3">Fixed height + Piped through value converter</button>
   </div>
-  <div if.bind="mode !== 2">
+  <div if.bind="mode === 1">
     <table class="table table-striped table-sm">
       <thead>
         <tr>
@@ -35,7 +38,7 @@
       </tbody>
     </table>
   </div>
-  <div else>
+  <div if.bind="mode === 2">
     <div class="scrollbar-y" style="height: 600px;">
       <table class="table table-striped table-sm">
         <thead>
@@ -49,6 +52,34 @@
         <tbody>
           <tr
             virtual-repeat.for="person of people"
+            infinite-scroll-next.call="push30($scrollContext)"
+            class="i-${$index}">
+            <td>${$index}</td>
+            <td>${person.fname}</td>
+            <td>${person.lname}</td>
+            <td>
+              <button type="button" class="btn btn-link"><i class="far fa-edit"></i></button>
+              <button type="button" class="btn btn-link"><i class="far fa-trash-alt"></i></button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div if.bind="mode === 3">
+    <div class="scrollbar-y" style="height: 600px;">
+      <table class="table table-striped table-sm">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            virtual-repeat.for="person of people | identity"
             infinite-scroll-next.call="push30($scrollContext)"
             class="i-${$index}">
             <td>${$index}</td>

--- a/sample/sample-v-ui-app/src/issue-117/sub-app.ts
+++ b/sample/sample-v-ui-app/src/issue-117/sub-app.ts
@@ -1,3 +1,5 @@
+import { BehaviorInstruction } from 'aurelia-framework';
+
 interface IScrollContext {
   isAtTop: boolean;
   isAtBottom: boolean;
@@ -17,7 +19,16 @@ const lNames = [
   // tslint:disable-next-line:max-line-length
   'Prefect', 'Dent', 'Astra', 'Adams', 'Baker', 'Clark', 'Davis', 'Evans', 'Frank', 'Ghosh', 'Hills', 'Irwin', 'Jones', 'Klein', 'Lopez', 'Mason', 'Nalty', 'Ochoa', 'Patel', 'Quinn', 'Reily', 'Smith', 'Trott', 'Usman', 'Valdo', 'White', 'Xiang', 'Yakub', 'Zafar'
 ];
+
 export class App {
+
+  static $resource = {
+    processContent: (_, __, ___, behaviorInstruction: BehaviorInstruction) => {
+      behaviorInstruction.inheritBindingContext = false;
+      return true;
+    }
+  };
+
   private people: Person[];
 
   constructor() {
@@ -27,6 +38,7 @@ export class App {
       { fname: fNames[2], lname: lNames[2] }
     ];
     this.push30(undefined, 5);
+    window['subapp'] = this;
   }
 
   public push30(scrollContext?: IScrollContext, count = 30) {

--- a/sample/sample-v-ui-app/src/issue-117/sub-app.ts
+++ b/sample/sample-v-ui-app/src/issue-117/sub-app.ts
@@ -42,10 +42,7 @@ export class App {
   }
 
   public push30(scrollContext?: IScrollContext, count = 30) {
-    console.log('Issue-129 getting more...');
-    // if (scrollContext) {
-    //   console.log('Issue-129 getting more:', JSON.stringify(scrollContext, undefined, 2));
-    // }
+    console.log('Issue-117 getting more...');
     if (!scrollContext || scrollContext.isAtBottom) {
       for (let i = 0; i < count; i++) {
         this.people.push({

--- a/sample/sample-v-ui-app/src/issue-129/sub-app.html
+++ b/sample/sample-v-ui-app/src/issue-129/sub-app.html
@@ -11,7 +11,9 @@
           </tr>
         </thead>
         <tbody>
-          <tr virtual-repeat.for="person of people" infinite-scroll-next.call="push30($scrollContext)">
+          <tr virtual-repeat.for="person of people"
+            infinite-scroll-next.call="push30($scrollContext)"
+            class="i-${$index}">
             <td>${$index}</td>
             <td>${person.fname}</td>
             <td>${person.lname}</td>

--- a/sample/sample-v-ui-app/src/nav-bar.html
+++ b/sample/sample-v-ui-app/src/nav-bar.html
@@ -4,15 +4,15 @@
       scrollbar-width: thin;
       scrollbar-color: royalblue;
     }
-    .sb.sb-x {
+    .sb.sb-x, .scrollbar-x {
       overflow-x: auto;
       overflow-y: hidden;
     }
-    .sb.sb-y {
+    .sb.sb-y, .scrollbar-y {
       overflow-x: hidden;
       overflow-y: auto;
     }
-    .sb::-webkit-scrollbar{
+    .sb::-webkit-scrollbar {
       width: 6px;
       background-color: rgba(224, 224, 224, 0.5);
     }

--- a/sample/sample-v-ui-app/src/non-issues/scroller-not-first-parent-div/sub-app.html
+++ b/sample/sample-v-ui-app/src/non-issues/scroller-not-first-parent-div/sub-app.html
@@ -21,7 +21,7 @@
       </div>
     </div>
   </div>
-   <style>
+  <style>
     .scroller {
       position: relative;
       height: 500px;

--- a/sample/sample-v-ui-app/src/non-issues/sub-app.html
+++ b/sample/sample-v-ui-app/src/non-issues/sub-app.html
@@ -3,7 +3,7 @@
     <a
       repeat.for="nav of router.navigation"
       href.bind='nav.href'
-      class='btn btn-sm btn-primary text-white mr-2'>${nav.title}</a>
+      class="btn btn-sm btn-${nav.isActive ? '' : 'outline-'}primary mr-2">${nav.title}</a>
   </div>
   <router-view></router-view>
 </template>

--- a/sample/sample-v-ui-app/src/non-issues/sub-app.ts
+++ b/sample/sample-v-ui-app/src/non-issues/sub-app.ts
@@ -1,6 +1,11 @@
-import { RouterConfiguration, Router } from "aurelia-router";
-import { PLATFORM } from "aurelia-pal";
+import { RouterConfiguration, Router } from 'aurelia-router';
+import { PLATFORM } from 'aurelia-pal';
+import { processContent, BehaviorInstruction } from 'aurelia-framework';
 
+@processContent((_: any, __: any, ___: any, behaviorInstuction: BehaviorInstruction) => {
+  behaviorInstuction.inheritBindingContext = false;
+  return true;
+})
 export class PromiseGetMoreApp {
 
   router: Router;

--- a/sample/sample-v-ui-app/src/phone-list.html
+++ b/sample/sample-v-ui-app/src/phone-list.html
@@ -24,7 +24,7 @@
   </div>
 
   <div if.bind="isVisible && selectedMarkup === 'div'">
-    <div virtual-repeat.for="item of objectArray" class="contact-list-item ${item.name}">
+    <div virtual-repeat.for="item of objectArray" class="contact-list-item ${item.name} i-${$index}">
       <div class="contact-item">
         <div class="avatar" click.trigger="click()" css="background-color: ${item.color}">${item.firstLetter}</div>
         <div class="name text-primary">

--- a/src/array-virtual-repeat-strategy.ts
+++ b/src/array-virtual-repeat-strategy.ts
@@ -1,5 +1,4 @@
 import { ICollectionObserverSplice, mergeSplice } from 'aurelia-binding';
-import { ViewSlot } from 'aurelia-templating';
 import { ArrayRepeatStrategy, createFullOverrideContext } from 'aurelia-templating-resources';
 import { IView, IVirtualRepeatStrategy, VirtualizationCalculation, IScrollerInfo, IVirtualRepeater, IViewSlot } from './interfaces';
 import {
@@ -12,8 +11,8 @@ import {
   Math$ceil
 } from './utilities';
 import { VirtualRepeat } from './virtual-repeat';
-import { getDistanceToParent, hasOverflowScroll, calcScrollHeight, calcOuterHeight } from './utilities-dom';
-import { htmlElement, $raf, BrowserConstants } from './constants';
+import { getDistanceToParent, calcOuterHeight } from './utilities-dom';
+import { htmlElement } from './constants';
 
 interface IArrayVirtualRepeater extends IVirtualRepeater {
   __queuedSplices: ICollectionObserverSplice[];

--- a/src/array-virtual-repeat-strategy.ts
+++ b/src/array-virtual-repeat-strategy.ts
@@ -18,7 +18,7 @@ import { htmlElement } from './constants';
  */
 export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy implements IVirtualRepeatStrategy {
 
-  createFirstItem(repeat: VirtualRepeat): IView {
+  createFirstRow(repeat: VirtualRepeat): IView {
     const overrideContext = createFullOverrideContext(repeat, repeat.items[0], 0, 1);
     return repeat.addView(overrideContext.bindingContext, overrideContext);
   }
@@ -35,7 +35,7 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy implements I
     const containerEl = repeat.getScroller();
     const existingViewCount = repeat.viewCount();
     if (itemCount > 0 && existingViewCount === 0) {
-      this.createFirstItem(repeat);
+      this.createFirstRow(repeat);
     }
     const isFixedHeightContainer = repeat._fixedHeightContainer = hasOverflowScroll(containerEl);
     const firstView = repeat._firstView();
@@ -117,7 +117,7 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy implements I
     return lastIndex === -1
       ? true
       : itemCount > 0
-        ? lastIndex >= (itemCount - repeat.edgeDistance)
+        ? lastIndex >= (itemCount - 1 - repeat.edgeDistance)
         : false;
   }
 
@@ -349,6 +349,7 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy implements I
     // only need to update bottom buffer
     const lastViewIndex = repeat._lastViewIndex();
     const all_splices_are_after_view_port = currViewCount > repeat.elementsInView && splices.every(s => s.index > lastViewIndex);
+
     if (all_splices_are_after_view_port) {
       repeat._bottomBufferHeight = Math$max(0, newArraySize - firstIndex - currViewCount) * itemHeight;
       repeat._updateBufferElements(true);

--- a/src/array-virtual-repeat-strategy.ts
+++ b/src/array-virtual-repeat-strategy.ts
@@ -278,7 +278,6 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy implements I
    */
   _runSplices(repeat: IVirtualRepeater, newArray: any[], splices: ICollectionObserverSplice[]): any {
     const firstIndex = repeat.$first;
-    // console.log('running splices', { firstIndex });
     // total remove count and total added count are used to determine original size of collection
     // before mutation happens, also can be used to determine some optmizable cases of mutation
     // such as case where all mutations happen after last visible view index
@@ -501,7 +500,6 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy implements I
   }
 
   remeasure(repeat: IVirtualRepeater): void {
-    // console.log('%cabstract remeasuring....', 'color:red');
     this._remeasure(repeat, repeat.itemHeight, repeat.viewCount(), repeat.items.length, repeat.firstViewIndex());
   }
 
@@ -527,18 +525,6 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy implements I
       let first_index_after_scroll_adjustment = real_scroll_top === 0
       ? 0
       : Math$floor(real_scroll_top / itemHeight);
-
-    // console.log('remeasuring array',
-    // {
-    //   top: repeat.topBufferHeight,
-    //   bot: repeat.bottomBufferHeight,
-    //   new_start: first_index_after_scroll_adjustment,
-    //   old_start: firstIndex,
-    //   view_count: newViewCount,
-    //   size: newArraySize,
-    //   real_scroll_top: real_scroll_top,
-    //   scroller_scroll_top: scroller_scroll_top
-    // });
 
     // if first index after scroll adjustment doesn't fit with number of possible view
     // it means the scroller has been too far down to the bottom and nolonger suitable to start from this index

--- a/src/array-virtual-repeat-strategy.ts
+++ b/src/array-virtual-repeat-strategy.ts
@@ -58,7 +58,7 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy implements I
 
   onAttached(repeat: VirtualRepeat): void {
     if (repeat.items.length < repeat.elementsInView) {
-      repeat._getMore2(0, /*is near top?*/true, this.isNearBottom(repeat, repeat._lastViewIndex()), /*force?*/true);
+      repeat._getMore(0, /*is near top?*/true, this.isNearBottom(repeat, repeat._lastViewIndex()), /*force?*/true);
     }
   }
 
@@ -424,15 +424,9 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy implements I
       }
       const newBotBufferItemCount = Math$max(0, newArraySize - newTopBufferItemCount - newViewCount);
 
-      // first update will be to mimic the behavior of a normal repeat mutation
-      // where real views are inserted, removed
-      // whenever there is a mutation, scroller variables will be updated
-      // can only start to correct views behavior after scroller has stabilized
-      repeat._isScrolling = false;
-      repeat._scrollingDown = repeat._scrollingUp = false;
       repeat._first = firstIndexAfterMutation;
-      repeat._previousFirst = firstIndex;
-      repeat._lastRebind = firstIndexAfterMutation + newViewCount;
+      // repeat._previousFirst = firstIndex;
+      // repeat._lastRebind = firstIndexAfterMutation + newViewCount;
       repeat._topBufferHeight = newTopBufferItemCount * itemHeight;
       repeat._bottomBufferHeight = newBotBufferItemCount * itemHeight;
       repeat._updateBufferElements(/*skip update?*/true);
@@ -478,42 +472,16 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy implements I
     }
     const top_buffer_item_count_after_scroll_adjustment = first_index_after_scroll_adjustment;
     const bot_buffer_item_count_after_scroll_adjustment = Math$max(0, newArraySize - top_buffer_item_count_after_scroll_adjustment - newViewCount);
-    repeat._first
-      = repeat._lastRebind = first_index_after_scroll_adjustment;
-    repeat._previousFirst = firstIndex;
-    repeat._isAtTop = first_index_after_scroll_adjustment === 0;
-    repeat._isLastIndex = bot_buffer_item_count_after_scroll_adjustment === 0;
+    repeat._first = first_index_after_scroll_adjustment;
+    // repeat._previousFirst = firstIndex;
+    // repeat._isAtTop = first_index_after_scroll_adjustment === 0;
+    // repeat._isLastIndex = bot_buffer_item_count_after_scroll_adjustment === 0;
     repeat._topBufferHeight = top_buffer_item_count_after_scroll_adjustment * itemHeight;
     repeat._bottomBufferHeight = bot_buffer_item_count_after_scroll_adjustment * itemHeight;
-    repeat._handlingMutations = false;
+    // repeat._handlingMutations = false;
     // prevent scroller update
     repeat.revertScrollCheckGuard();
     repeat._updateBufferElements();
     updateAllViews(repeat, 0);
-  }
-
-  /**@internal */
-  _isIndexBeforeViewSlot(repeat: VirtualRepeat, viewSlot: ViewSlot, index: number): boolean {
-    const viewIndex = this._getViewIndex(repeat, viewSlot, index);
-    return viewIndex < 0;
-  }
-
-  /**@internal */
-  _isIndexAfterViewSlot(repeat: VirtualRepeat, viewSlot: ViewSlot, index: number): boolean {
-    const viewIndex = this._getViewIndex(repeat, viewSlot, index);
-    return viewIndex > repeat._viewsLength - 1;
-  }
-
-  /**
-   * @internal
-   * Calculate real index of a given index, based on existing buffer height and item height
-   */
-  _getViewIndex(repeat: VirtualRepeat, viewSlot: ViewSlot, index: number): number {
-    if (repeat.viewCount() === 0) {
-      return -1;
-    }
-
-    const topBufferItems = repeat._topBufferHeight / repeat.itemHeight;
-    return Math$floor(index - topBufferItems);
   }
 }

--- a/src/array-virtual-repeat-strategy.ts
+++ b/src/array-virtual-repeat-strategy.ts
@@ -486,6 +486,7 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy implements I
     let first_index_after_scroll_adjustment = realScrolltop === 0
       ? 0
       : Math$floor(realScrolltop / itemHeight);
+
     // if first index after scroll adjustment doesn't fit with number of possible view
     // it means the scroller has been too far down to the bottom and nolonger suitable to start from this index
     // rollback until all views fit into new collection, or until has enough collection item to render
@@ -500,7 +501,7 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy implements I
     // repeat._isLastIndex = bot_buffer_item_count_after_scroll_adjustment === 0;
     repeat.topBufferHeight = top_buffer_item_count_after_scroll_adjustment * itemHeight;
     repeat.bottomBufferHeight = bot_buffer_item_count_after_scroll_adjustment * itemHeight;
-    // repeat._handlingMutations = false;
+    (repeat as VirtualRepeat)._handlingMutations = false;
     // ensure scroller scroll is handled
     (repeat as VirtualRepeat).revertScrollCheckGuard();
     repeat.updateBufferElements();

--- a/src/aurelia-ui-virtualization.ts
+++ b/src/aurelia-ui-virtualization.ts
@@ -17,3 +17,7 @@ export {
   IScrollNextScrollContext,
   VirtualizationEvents
 } from './interfaces';
+
+export {
+  BrowserConstants
+} from './constants';

--- a/src/aurelia-ui-virtualization.ts
+++ b/src/aurelia-ui-virtualization.ts
@@ -17,7 +17,3 @@ export {
   IScrollNextScrollContext,
   VirtualizationEvents
 } from './interfaces';
-
-export {
-  BrowserConstants
-} from './constants';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,3 @@
 export const doc = document;
 export const htmlElement = doc.documentElement;
+export const $raf = requestAnimationFrame;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+export const doc = document;
+export const htmlElement = doc.documentElement;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,14 +1,3 @@
 export const doc = document;
 export const htmlElement = doc.documentElement;
 export const $raf = requestAnimationFrame;
-
-export interface IBrowserConstants {
-  /**
-   * Indicates how far browser will scroll each scroll jump in not smooth scrolling mode
-   */
-  scrollStep: number;
-}
-
-export const BrowserConstants: IBrowserConstants = {
-  scrollStep: 100
-};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,14 @@
 export const doc = document;
 export const htmlElement = doc.documentElement;
 export const $raf = requestAnimationFrame;
+
+export interface IBrowserConstants {
+  /**
+   * Indicates how far browser will scroll each scroll jump in not smooth scrolling mode
+   */
+  scrollStep: number;
+}
+
+export const BrowserConstants: IBrowserConstants = {
+  scrollStep: 100
+};

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -197,16 +197,6 @@ export const enum VirtualizationCalculation {
   observe_scroller  = 0b0_00100
 }
 
-export const enum VirtualiationScrollState {
-  none              = 0,
-  isAtTop           = 0b0_000001,
-  isAtBottom        = 0b0_000010,
-  scrolling         = 0b0_000100,
-  scrollingDown     = 0b0_001000,
-  scrollingUp       = 0b0_010000,
-  switchedDirection = 0b0_100000
-}
-
 /**
  * List of events that can be used to notify virtual repeat that size has changed
  */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,6 @@
 import { Binding, Scope, ICollectionObserverSplice, ObserverLocator, InternalCollectionObserver, OverrideContext } from 'aurelia-binding';
 import { TaskQueue } from 'aurelia-task-queue';
-import { View, ViewSlot } from 'aurelia-templating';
+import { View, ViewSlot, Controller } from 'aurelia-templating';
 import { RepeatStrategy } from 'aurelia-templating-resources';
 import { VirtualRepeat } from './virtual-repeat';
 
@@ -48,7 +48,7 @@ export interface IVirtualRepeatStrategy extends RepeatStrategy {
   /**
    * create first item to calculate the heights
    */
-  createFirstItem(repeat: VirtualRepeat): IView;
+  createFirstRow(repeat: VirtualRepeat): IView;
 
   /**
    * Calculate required variables for a virtual repeat instance to operate properly
@@ -195,6 +195,13 @@ export const enum VirtualizationCalculation {
   reset             = 0b0_00001,
   has_sizing        = 0b0_00010,
   observe_scroller  = 0b0_00100
+}
+
+export interface IElement {
+  au: {
+    controller: Controller;
+    [key: string]: any;
+  };
 }
 
 /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -185,7 +185,7 @@ export interface IOverrideContext<T> extends OverrideContext {
  */
 export interface IScrollerInfo {
   scroller: HTMLElement;
-  scrollHeight: number;
+  // scrollHeight: number;
   scrollTop: number;
   height: number;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,7 +1,7 @@
 import { Binding, Scope, ICollectionObserverSplice, ObserverLocator, InternalCollectionObserver, OverrideContext } from 'aurelia-binding';
 import { TaskQueue } from 'aurelia-task-queue';
 import { View, ViewSlot, Controller } from 'aurelia-templating';
-import { RepeatStrategy } from 'aurelia-templating-resources';
+import { RepeatStrategy, AbstractRepeater } from 'aurelia-templating-resources';
 import { VirtualRepeat } from './virtual-repeat';
 
 export interface IScrollNextScrollContext {
@@ -41,6 +41,142 @@ declare module 'aurelia-templating' {
   interface Controller {
     boundProperties: { binding: Binding }[];
   }
+}
+
+export interface IVirtualRepeater extends AbstractRepeater {
+
+  items: any;
+
+  local?: string;
+
+  /**
+   * First view index, for proper follow up calculations
+   */
+  $first: number;
+
+  /**
+   * Defines how many items there should be for a given index to be considered at edge
+   */
+  edgeDistance: number;
+
+  /**
+   * Template handling strategy for this repeat.
+   */
+  templateStrategy: ITemplateStrategy;
+
+  /**
+   * Top buffer element, used to reflect the visualization of amount of items `before` the first visible item
+   * @internal
+   */
+  topBufferEl: HTMLElement;
+
+  /**
+   * Bot buffer element, used to reflect the visualization of amount of items `after` the first visible item
+   */
+  bottomBufferEl: HTMLElement;
+
+  /**
+   * Height of top buffer to properly push the visible rendered list items into right position
+   * Usually determined by `_first` visible index * `itemHeight`
+   */
+  topBufferHeight: number;
+
+  /**
+   * Height of bottom buffer to properly push the visible rendered list items into right position
+   */
+  bottomBufferHeight: number;
+
+  /**
+   * Height of each item. Calculated based on first item
+   */
+  itemHeight: number;
+
+  /**
+   * Calculate current scrolltop position
+   */
+  distanceToTop: number;
+
+  /**
+   * Number indicating minimum elements required to render to fill up the visible viewport
+   */
+  minViewsRequired: number;
+
+  /**
+   * Indicates whether virtual repeat attribute is inside a fixed height container with overflow
+   *
+   * This helps identifies place to add scroll event listener
+   */
+  fixedHeightContainer: boolean;
+
+  /**
+   * ViewSlot that encapsulates the repeater views operations in the template
+   */
+  readonly viewSlot: ViewSlot;
+
+  /**
+   * Aurelia change handler by convention for property `items`. Used to properly determine action
+   * needed when items value has been changed
+   */
+  itemsChanged(): void;
+
+  /**
+   * Get first visible view
+   */
+  firstView(): IView | null;
+
+  /**
+   * Get last visible view
+   */
+  lastView(): IView | null;
+
+  /**
+   * Get index of first visible view
+   */
+  firstViewIndex(): number;
+
+  /**
+   * Get index of last visible view
+   */
+  lastViewIndex(): number;
+
+  /**
+   * Invoke infinite scroll next function expression with currently bound scope of the repeater
+   */
+  getMore(topIndex: number, isNearTop: boolean, isNearBottom: boolean, force?: boolean): void;
+
+  /**
+   * Get the real scroller element of the DOM tree this repeat resides in
+   */
+  getScroller(): HTMLElement;
+
+  /**
+   * Get scrolling information of the real scroller element of the DOM tree this repeat resides in
+   */
+  getScrollerInfo(): IScrollerInfo;
+
+  /**
+   * Observe scroller element to react upon sizing changes
+   */
+  observeScroller(scrollerEl: HTMLElement): void;
+
+  /**
+   * Dispose scroller content size observer, if has
+   * Dispose all event listeners related to sizing of scroller, if any
+   */
+  unobserveScroller(): void;
+
+  /**
+   * Signal the repeater to reset all its internal calculation states.
+   * Typically used when items value is null, undefined, empty collection.
+   * Or the repeater has been detached
+   */
+  resetCalculation(): void;
+
+  /**
+   * Update buffer elements height/width with corresponding
+   * @param skipUpdate `true` to signal this repeater that the update won't trigger scroll event
+   */
+  updateBufferElements(skipUpdate?: boolean): void;
 }
 
 export interface IVirtualRepeatStrategy extends RepeatStrategy {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -65,6 +65,11 @@ export interface IVirtualRepeater extends AbstractRepeater {
   templateStrategy: ITemplateStrategy;
 
   /**
+   * The element hosting the scrollbar for this repeater
+   */
+  scrollerEl: HTMLElement;
+
+  /**
    * Top buffer element, used to reflect the visualization of amount of items `before` the first visible item
    * @internal
    */
@@ -101,12 +106,12 @@ export interface IVirtualRepeater extends AbstractRepeater {
    */
   minViewsRequired: number;
 
-  /**
-   * Indicates whether virtual repeat attribute is inside a fixed height container with overflow
-   *
-   * This helps identifies place to add scroll event listener
-   */
-  fixedHeightContainer: boolean;
+  // /**
+  //  * Indicates whether virtual repeat attribute is inside a fixed height container with overflow
+  //  *
+  //  * This helps identifies place to add scroll event listener
+  //  */
+  // fixedHeightContainer: boolean;
 
   /**
    * ViewSlot that encapsulates the repeater views operations in the template
@@ -138,6 +143,12 @@ export interface IVirtualRepeater extends AbstractRepeater {
    * Get index of last visible view
    */
   lastViewIndex(): number;
+
+  /**
+   * Virtual repeater normally employs scroll handling buffer for performance reasons.
+   * As syncing between scrolling state and visible views could be expensive.
+   */
+  enableScroll(): void;
 
   /**
    * Invoke infinite scroll next function expression with currently bound scope of the repeater
@@ -354,6 +365,14 @@ export const VirtualizationEvents = Object.assign(Object.create(null), {
   scrollerSizeChange: 'virtual-repeat-scroller-size-changed';
   itemSizeChange: 'virtual-repeat-item-size-changed';
 };
+
+export const enum ScrollingState {
+  none              = 0,
+  isScrollingDown   = 0b0_00001,
+  isScrollingUp     = 0b0_00010,
+  isNearTop         = 0b0_00100,
+  isNearBottom      = 0b0_01000
+}
 
 // export const enum IVirtualRepeatState {
 //   isAtTop = 0b0_000000_000,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -179,46 +179,45 @@ export interface IVirtualRepeater extends AbstractRepeater {
   updateBufferElements(skipUpdate?: boolean): void;
 }
 
-export interface IVirtualRepeatStrategy extends RepeatStrategy {
-
+export interface IVirtualRepeatStrategy {
   /**
    * create first item to calculate the heights
    */
-  createFirstRow(repeat: VirtualRepeat): IView;
+  createFirstRow(repeat: IVirtualRepeater): IView;
 
   /**
    * Calculate required variables for a virtual repeat instance to operate properly
    *
    * @returns `false` to notify that calculation hasn't been finished
    */
-  initCalculation(repeat: VirtualRepeat, items: number | any[] | Map<any, any> | Set<any>): VirtualizationCalculation;
+  initCalculation(repeat: IVirtualRepeater, items: number | any[] | Map<any, any> | Set<any>): VirtualizationCalculation;
 
   /**
    * Handle special initialization if any, depends on different strategy
    */
-  onAttached(repeat: VirtualRepeat): void;
+  onAttached(repeat: IVirtualRepeater): void;
 
   /**
    * Calculate the start and end index of a repeat based on its container current scroll position
    */
-  getViewRange(repeat: VirtualRepeat, scrollerInfo: IScrollerInfo): [number, number];
+  getViewRange(repeat: IVirtualRepeater, scrollerInfo: IScrollerInfo): [number, number];
 
   /**
    * Returns true if first index is approaching start of the collection
    * Virtual repeat can use this to invoke infinite scroll next
    */
-  isNearTop(repeat: VirtualRepeat, firstIndex: number): boolean;
+  isNearTop(repeat: IVirtualRepeater, firstIndex: number): boolean;
 
   /**
    * Returns true if last index is approaching end of the collection
    * Virtual repeat can use this to invoke infinite scroll next
    */
-  isNearBottom(repeat: VirtualRepeat, lastIndex: number): boolean;
+  isNearBottom(repeat: IVirtualRepeater, lastIndex: number): boolean;
 
   /**
    * Update repeat buffers height based on repeat.items
    */
-  updateBuffers(repeat: VirtualRepeat, firstIndex: number): void;
+  updateBuffers(repeat: IVirtualRepeater, firstIndex: number): void;
 
   /**
    * Get the observer based on collection type of `items`
@@ -232,7 +231,7 @@ export interface IVirtualRepeatStrategy extends RepeatStrategy {
    * @param items The new array instance.
    * @param firstIndex The index of first active view
    */
-  instanceChanged(repeat: VirtualRepeat, items: any[] | Map<any, any> | Set<any>, firstIndex?: number): void;
+  instanceChanged(repeat: IVirtualRepeater, items: any[] | Map<any, any> | Set<any>, firstIndex?: number): void;
 
   /**
    * @override
@@ -241,7 +240,7 @@ export interface IVirtualRepeatStrategy extends RepeatStrategy {
    * @param array The modified array.
    * @param splices Records of array changes.
    */
-  instanceMutated(repeat: VirtualRepeat, array: any[], splices: ICollectionObserverSplice[]): void;
+  instanceMutated(repeat: IVirtualRepeater, array: any[], splices: ICollectionObserverSplice[]): void;
 
   /**
    * Unlike normal repeat, virtualization repeat employs "padding" elements. Those elements
@@ -253,7 +252,12 @@ export interface IVirtualRepeatStrategy extends RepeatStrategy {
    *
    * This is 2 phases scroll handle
    */
-  remeasure(repeat: VirtualRepeat): void;
+  remeasure(repeat: IVirtualRepeater): void;
+
+  /**
+   * Update all visible views of a repeater, starting from given `startIndex`
+   */
+  updateAllViews(repeat: IVirtualRepeater, startIndex: number): void;
 }
 
 /**

--- a/src/null-virtual-repeat-strategy.ts
+++ b/src/null-virtual-repeat-strategy.ts
@@ -40,7 +40,7 @@ export class NullVirtualRepeatStrategy extends NullRepeatStrategy implements IVi
 
   instanceChanged(repeat: VirtualRepeat): void {
     repeat.removeAllViews(/**return to cache?*/true, /**skip animation?*/false);
-    repeat._resetCalculation();
+    repeat.resetCalculation();
   }
 
   remeasure(repeat: VirtualRepeat): void {/*empty*/}

--- a/src/null-virtual-repeat-strategy.ts
+++ b/src/null-virtual-repeat-strategy.ts
@@ -5,12 +5,10 @@ import { IVirtualRepeatStrategy, IView, VirtualizationCalculation, IScrollerInfo
 export class NullVirtualRepeatStrategy extends NullRepeatStrategy implements IVirtualRepeatStrategy {
 
   getViewRange(repeat: VirtualRepeat, scrollerInfo: IScrollerInfo): [number, number] {
-    throw new Error('Method not implemented.');
+    return [0, 0];
   }
 
-  updateBuffers(repeat: VirtualRepeat, firstIndex: number): void {
-    throw new Error('Method not implemented.');
-  }
+  updateBuffers(repeat: VirtualRepeat, firstIndex: number): void {/*empty*/}
 
   onAttached() {/*empty*/}
 
@@ -44,7 +42,5 @@ export class NullVirtualRepeatStrategy extends NullRepeatStrategy implements IVi
     repeat._resetCalculation();
   }
 
-  remeasure(repeat: VirtualRepeat): void {
-    throw new Error('Method not implemented.');
-  }
+  remeasure(repeat: VirtualRepeat): void {/*empty*/}
 }

--- a/src/null-virtual-repeat-strategy.ts
+++ b/src/null-virtual-repeat-strategy.ts
@@ -22,8 +22,8 @@ export class NullVirtualRepeatStrategy extends NullRepeatStrategy implements IVi
 
   initCalculation(repeat: VirtualRepeat, items: any): VirtualizationCalculation {
     repeat.itemHeight
-      = repeat.elementsInView
-      = repeat._viewsLength
+      = repeat.minViewsRequired
+      // = repeat._viewsLength
       = 0;
     // null/undefined virtual repeat strategy does not require any calculation
     // returning has_sizing to signal that

--- a/src/null-virtual-repeat-strategy.ts
+++ b/src/null-virtual-repeat-strategy.ts
@@ -1,8 +1,26 @@
 import { NullRepeatStrategy, RepeatStrategy } from 'aurelia-templating-resources';
 import { VirtualRepeat } from './virtual-repeat';
-import { IVirtualRepeatStrategy, IView, VirtualizationCalculation } from './interfaces';
+import { IVirtualRepeatStrategy, IView, VirtualizationCalculation, IScrollerInfo } from './interfaces';
 
 export class NullVirtualRepeatStrategy extends NullRepeatStrategy implements IVirtualRepeatStrategy {
+
+  getViewRange(repeat: VirtualRepeat, scrollerInfo: IScrollerInfo): [number, number] {
+    throw new Error('Method not implemented.');
+  }
+
+  updateBuffers(repeat: VirtualRepeat, firstIndex: number): void {
+    throw new Error('Method not implemented.');
+  }
+
+  onAttached() {/*empty*/}
+
+  isNearTop(): boolean {
+    return false;
+  }
+
+  isNearBottom(): boolean {
+    return false;
+  }
 
   initCalculation(repeat: VirtualRepeat, items: any): VirtualizationCalculation {
     repeat.itemHeight
@@ -19,10 +37,14 @@ export class NullVirtualRepeatStrategy extends NullRepeatStrategy implements IVi
     return null;
   }
 
-  instanceMutated() {/**/}
+  instanceMutated() {/*empty*/}
 
   instanceChanged(repeat: VirtualRepeat): void {
     repeat.removeAllViews(/**return to cache?*/true, /**skip animation?*/false);
     repeat._resetCalculation();
+  }
+
+  remeasure(repeat: VirtualRepeat): void {
+    throw new Error('Method not implemented.');
   }
 }

--- a/src/null-virtual-repeat-strategy.ts
+++ b/src/null-virtual-repeat-strategy.ts
@@ -23,7 +23,8 @@ export class NullVirtualRepeatStrategy extends NullRepeatStrategy implements IVi
   initCalculation(repeat: VirtualRepeat, items: any): VirtualizationCalculation {
     repeat.itemHeight
       = repeat.elementsInView
-      = repeat._viewsLength = 0;
+      = repeat._viewsLength
+      = 0;
     // null/undefined virtual repeat strategy does not require any calculation
     // returning has_sizing to signal that
     return VirtualizationCalculation.has_sizing;
@@ -31,7 +32,7 @@ export class NullVirtualRepeatStrategy extends NullRepeatStrategy implements IVi
 
   // a violation of base contract, won't work in strict mode
   // todo: fix this API design
-  createFirstItem(): IView | null {
+  createFirstRow(): IView | null {
     return null;
   }
 

--- a/src/null-virtual-repeat-strategy.ts
+++ b/src/null-virtual-repeat-strategy.ts
@@ -44,4 +44,6 @@ export class NullVirtualRepeatStrategy extends NullRepeatStrategy implements IVi
   }
 
   remeasure(repeat: VirtualRepeat): void {/*empty*/}
+
+  updateAllViews(): void {/*empty*/}
 }

--- a/src/template-strategy-default.ts
+++ b/src/template-strategy-default.ts
@@ -1,5 +1,5 @@
 import { IView, ITemplateStrategy } from './interfaces';
-import { insertBeforeNode, getScrollContainer } from './utilities-dom';
+import { insertBeforeNode, getScrollerElement } from './utilities-dom';
 import { DOM } from 'aurelia-pal';
 
 /**
@@ -8,7 +8,7 @@ import { DOM } from 'aurelia-pal';
 export class DefaultTemplateStrategy implements ITemplateStrategy {
 
   getScrollContainer(element: Element): HTMLElement {
-    return getScrollContainer(element);
+    return getScrollerElement(element);
   }
 
   moveViewFirst(view: IView, topBuffer: Element): void {

--- a/src/template-strategy-default.ts
+++ b/src/template-strategy-default.ts
@@ -2,6 +2,9 @@ import { IView, ITemplateStrategy } from './interfaces';
 import { insertBeforeNode, getScrollContainer } from './utilities-dom';
 import { DOM } from 'aurelia-pal';
 
+/**
+ * A template strategy for any virtual repeat usage that is not placed on tr, tbody, li, dd
+ */
 export class DefaultTemplateStrategy implements ITemplateStrategy {
 
   getScrollContainer(element: Element): HTMLElement {

--- a/src/template-strategy-list.ts
+++ b/src/template-strategy-list.ts
@@ -34,23 +34,11 @@ import { hasOverflowScroll } from './utilities-dom';
 export class ListTemplateStrategy extends DefaultTemplateStrategy implements ITemplateStrategy {
 
   /**@override */
-  getScrollContainer(element: Element): HTMLElement {
-    let listElement = this.getList(element);
-    return hasOverflowScroll(listElement)
-      ? listElement
-      : listElement.parentNode as HTMLElement;
-  }
-
-  /**@override */
   createBuffers(element: Element): [HTMLElement, HTMLElement] {
     const parent = element.parentNode;
     return [
       parent.insertBefore(DOM.createElement('li'), element),
       parent.insertBefore(DOM.createElement('li'), element.nextSibling)
     ];
-  }
-
-  private getList(element: Element): HTMLOListElement | HTMLUListElement {
-    return element.parentNode as HTMLOListElement | HTMLUListElement;
   }
 }

--- a/src/template-strategy-table.ts
+++ b/src/template-strategy-table.ts
@@ -1,12 +1,13 @@
 import { DOM } from 'aurelia-pal';
 import { ITemplateStrategy } from './interfaces';
 import { DefaultTemplateStrategy } from './template-strategy-default';
+import { getScrollContainer } from './utilities-dom';
 
 abstract class BaseTableTemplateStrategy extends DefaultTemplateStrategy implements ITemplateStrategy {
 
   /**@override */
   getScrollContainer(element: Element): HTMLElement {
-    return this.getTable(element).parentNode as HTMLElement;
+    return getScrollContainer(this.getTable(element));
   }
 
   createBuffers(element: Element): [HTMLElement, HTMLElement] {

--- a/src/template-strategy-table.ts
+++ b/src/template-strategy-table.ts
@@ -1,13 +1,13 @@
 import { DOM } from 'aurelia-pal';
 import { ITemplateStrategy } from './interfaces';
 import { DefaultTemplateStrategy } from './template-strategy-default';
-import { getScrollContainer } from './utilities-dom';
+import { getScrollerElement } from './utilities-dom';
 
 abstract class BaseTableTemplateStrategy extends DefaultTemplateStrategy implements ITemplateStrategy {
 
   /**@override */
   getScrollContainer(element: Element): HTMLElement {
-    return getScrollContainer(this.getTable(element));
+    return getScrollerElement(this.getTable(element));
   }
 
   createBuffers(element: Element): [HTMLElement, HTMLElement] {

--- a/src/utilities-dom.ts
+++ b/src/utilities-dom.ts
@@ -1,5 +1,6 @@
 import { Math$round, $isNaN } from './utilities';
 import { IView } from './interfaces';
+import { htmlElement } from './constants';
 
 /**
  * Walk up the DOM tree and determine what element will be scroller for an element
@@ -14,7 +15,7 @@ export const getScrollContainer = (element: Node): HTMLElement => {
     }
     current = current.parentNode as HTMLElement;
   }
-  return document.documentElement;
+  return htmlElement;
 };
 
 /**
@@ -22,9 +23,8 @@ export const getScrollContainer = (element: Node): HTMLElement => {
  */
 export const getElementDistanceToTopOfDocument = (element: Element): number => {
   let box = element.getBoundingClientRect();
-  let documentElement = document.documentElement;
   let scrollTop = window.pageYOffset;
-  let clientTop = documentElement.clientTop;
+  let clientTop = htmlElement.clientTop;
   let top  = box.top + scrollTop - clientTop;
   return Math$round(top);
 };
@@ -74,12 +74,7 @@ export const insertBeforeNode = (view: IView, bottomBuffer: Element): void => {
  * child.offsetTop - parent.offsetTop
  * There are steps in the middle to account for offsetParent but it's basically that
  */
-export const getDistanceToParent = (child: HTMLElement, parent: HTMLElement) => {
-  // optimizable case where child is the first child of parent
-  // and parent is the target parent to calculate
-  if (child.previousSibling === null && child.parentNode === parent) {
-    return 0;
-  }
+export const getDistanceToParent = (child: HTMLElement, parent: HTMLElement): number => {
   const offsetParent = child.offsetParent as HTMLElement;
   const childOffsetTop = child.offsetTop;
   // [el] <-- offset parent === parent

--- a/src/utilities-dom.ts
+++ b/src/utilities-dom.ts
@@ -7,9 +7,9 @@ import { htmlElement } from './constants';
  *
  * If none is found, return `document.documentElement`
  */
-export const getScrollContainer = (element: Node): HTMLElement => {
-  let current = element.parentNode;
-  while (current !== null && current !== document) {
+export const getScrollerElement = (element: Node): HTMLElement => {
+  let current = element.parentNode as Element;
+  while (current !== null && current !== htmlElement) {
     if (hasOverflowScroll(current)) {
       return current as HTMLElement;
     }
@@ -32,7 +32,7 @@ export const getElementDistanceToTopOfDocument = (element: Element): number => {
 /**
  * Check if an element has style scroll/auto for overflow/overflowY
  */
-export const hasOverflowScroll = (element): boolean => {
+export const hasOverflowScroll = (element: Element): boolean => {
   const style = window.getComputedStyle(element);
   return style && (style.overflowY === 'scroll' || style.overflow === 'scroll' || style.overflowY === 'auto' || style.overflow === 'auto');
 };
@@ -45,7 +45,7 @@ export const getStyleValues = (element: Element, ...styles: string[]): number =>
   let value: number = 0;
   let styleValue: number = 0;
   for (let i = 0, ii = styles.length; ii > i; ++i) {
-    styleValue = parseInt(currentStyle[styles[i]], 10);
+    styleValue = parseFloat(currentStyle[styles[i]]);
     value += $isNaN(styleValue) ? 0 : styleValue;
   }
   return value;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,6 +1,6 @@
 import { updateOverrideContext } from 'aurelia-templating-resources';
 import { VirtualRepeat } from './virtual-repeat';
-import { IView } from './interfaces';
+import { IView, VirtualiationScrollState, IScrollerInfo } from './interfaces';
 
 
 /**
@@ -30,7 +30,7 @@ export const updateAllViews = (repeat: VirtualRepeat, startIndex: number): void 
 
   const delta = Math$floor(repeat._topBufferHeight / repeat.itemHeight);
   let collectionIndex = 0;
-  let view;
+  let view: IView;
 
   for (; viewLength > startIndex; ++startIndex) {
     collectionIndex = startIndex + delta;
@@ -72,3 +72,32 @@ export const Math$round = Math.round;
 export const Math$ceil = Math.ceil;
 export const Math$floor = Math.floor;
 export const $isNaN = isNaN;
+
+/**
+ * On scroll event:
+ * - Set flags based on internal values of first view index, previous view index
+ * - Determines scrolling state, scroll direction, switching scroll direction
+ * @internal
+ */
+export const getScrollingState = (
+  previousState: VirtualiationScrollState,
+  currentScrollerInfo: IScrollerInfo,
+  prevScrollerInfo: IScrollerInfo
+): VirtualiationScrollState => {
+  const currTop = currentScrollerInfo.scrollTop;
+  const prevTop = prevScrollerInfo.scrollTop;
+  const isScrolling = currTop !== prevTop;
+  let scrollState = isScrolling ? VirtualiationScrollState.scrolling : 0;
+  let scrollingDown = currTop > prevTop;
+
+  scrollState |= scrollingDown
+    ? VirtualiationScrollState.scrollingDown
+    : VirtualiationScrollState.scrollingUp;
+
+  if ((scrollingDown && !(previousState & VirtualiationScrollState.scrollingDown))
+    || (!scrollingDown && (previousState & VirtualiationScrollState.scrollingDown))
+  ) {
+    scrollState |= VirtualiationScrollState.switchedDirection;
+  }
+  return scrollState;
+};

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,13 +1,13 @@
 import { updateOverrideContext } from 'aurelia-templating-resources';
 import { VirtualRepeat } from './virtual-repeat';
-import { IView } from './interfaces';
+import { IView, IVirtualRepeater, IViewSlot } from './interfaces';
 
 /**
 * Update the override context.
 * @param startIndex index in collection where to start updating.
 */
-export const updateVirtualOverrideContexts = (repeat: VirtualRepeat, startIndex: number): void => {
-  const views = repeat.viewSlot.children;
+export const updateVirtualOverrideContexts = (repeat: IVirtualRepeater, startIndex: number): void => {
+  const views = (repeat.viewSlot as IViewSlot).children;
   const viewLength = views.length;
   const collectionLength = repeat.items.length;
 
@@ -15,19 +15,19 @@ export const updateVirtualOverrideContexts = (repeat: VirtualRepeat, startIndex:
     startIndex = startIndex - 1;
   }
 
-  const delta = repeat._topBufferHeight / repeat.itemHeight;
+  const delta = repeat.topBufferHeight / repeat.itemHeight;
 
   for (; viewLength > startIndex; ++startIndex) {
     updateOverrideContext(views[startIndex].overrideContext, startIndex + delta, collectionLength);
   }
 };
 
-export const updateAllViews = (repeat: VirtualRepeat, startIndex: number): void => {
-  const views = repeat.viewSlot.children;
+export const updateAllViews = (repeat: IVirtualRepeater, startIndex: number): void => {
+  const views = (repeat.viewSlot as IViewSlot).children;
   const viewLength = views.length;
   const collection = repeat.items;
 
-  const delta = Math$floor(repeat._topBufferHeight / repeat.itemHeight);
+  const delta = Math$floor(repeat.topBufferHeight / repeat.itemHeight);
   let collectionIndex = 0;
   let view: IView;
 
@@ -39,14 +39,14 @@ export const updateAllViews = (repeat: VirtualRepeat, startIndex: number): void 
   }
 };
 
-export const rebindView = (repeat: VirtualRepeat, view: IView, collectionIndex: number, collection: any[]): void => {
+export const rebindView = (repeat: IVirtualRepeater, view: IView, collectionIndex: number, collection: any[]): void => {
   view.bindingContext[repeat.local] = collection[collectionIndex];
   updateOverrideContext(view.overrideContext, collectionIndex, collection.length);
 };
 
-export const rebindAndMoveView = (repeat: VirtualRepeat, view: IView, index: number, moveToBottom: boolean): void => {
+export const rebindAndMoveView = (repeat: IVirtualRepeater, view: IView, index: number, moveToBottom: boolean): void => {
   const items = repeat.items;
-  const viewSlot = repeat.viewSlot;
+  const viewSlot = repeat.viewSlot as IViewSlot;
 
   updateOverrideContext(view.overrideContext, index, items.length);
   view.bindingContext[repeat.local] = items[index];

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,6 +1,6 @@
 import { updateOverrideContext } from 'aurelia-templating-resources';
 import { VirtualRepeat } from './virtual-repeat';
-import { IView, VirtualiationScrollState, IScrollerInfo } from './interfaces';
+import { IView } from './interfaces';
 
 
 /**
@@ -72,32 +72,3 @@ export const Math$round = Math.round;
 export const Math$ceil = Math.ceil;
 export const Math$floor = Math.floor;
 export const $isNaN = isNaN;
-
-/**
- * On scroll event:
- * - Set flags based on internal values of first view index, previous view index
- * - Determines scrolling state, scroll direction, switching scroll direction
- * @internal
- */
-export const getScrollingState = (
-  previousState: VirtualiationScrollState,
-  currentScrollerInfo: IScrollerInfo,
-  prevScrollerInfo: IScrollerInfo
-): VirtualiationScrollState => {
-  const currTop = currentScrollerInfo.scrollTop;
-  const prevTop = prevScrollerInfo.scrollTop;
-  const isScrolling = currTop !== prevTop;
-  let scrollState = isScrolling ? VirtualiationScrollState.scrolling : 0;
-  let scrollingDown = currTop > prevTop;
-
-  scrollState |= scrollingDown
-    ? VirtualiationScrollState.scrollingDown
-    : VirtualiationScrollState.scrollingUp;
-
-  if ((scrollingDown && !(previousState & VirtualiationScrollState.scrollingDown))
-    || (!scrollingDown && (previousState & VirtualiationScrollState.scrollingDown))
-  ) {
-    scrollState |= VirtualiationScrollState.switchedDirection;
-  }
-  return scrollState;
-};

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -2,7 +2,6 @@ import { updateOverrideContext } from 'aurelia-templating-resources';
 import { VirtualRepeat } from './virtual-repeat';
 import { IView } from './interfaces';
 
-
 /**
 * Update the override context.
 * @param startIndex index in collection where to start updating.
@@ -60,9 +59,13 @@ export const rebindAndMoveView = (repeat: VirtualRepeat, view: IView, index: num
   }
 };
 
-
-export const getElementDistanceToBottomViewPort = (element: Element): number => {
-  return document.documentElement.clientHeight - element.getBoundingClientRect().bottom;
+/**
+ * Calculate min number of views required to fill up the viewport based on viewport height and item height
+ */
+export const calcMinViewsRequired = (scrollerHeight: number, itemHeight: number) => {
+  // extra 1 item to make sure it always fill up the viewport
+  // in case first item is scroll up but not enough to completely pushed out of the viewport
+  return Math$floor(scrollerHeight / itemHeight) + 1;
 };
 
 export const Math$abs = Math.abs;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -22,23 +22,6 @@ export const updateVirtualOverrideContexts = (repeat: IVirtualRepeater, startInd
   }
 };
 
-export const updateAllViews = (repeat: IVirtualRepeater, startIndex: number): void => {
-  const views = (repeat.viewSlot as IViewSlot).children;
-  const viewLength = views.length;
-  const collection = repeat.items;
-
-  const delta = Math$floor(repeat.topBufferHeight / repeat.itemHeight);
-  let collectionIndex = 0;
-  let view: IView;
-
-  for (; viewLength > startIndex; ++startIndex) {
-    collectionIndex = startIndex + delta;
-    view = repeat.view(startIndex);
-    rebindView(repeat, view, collectionIndex, collection);
-    repeat.updateBindings(view);
-  }
-};
-
 export const rebindView = (repeat: IVirtualRepeater, view: IView, collectionIndex: number, collection: any[]): void => {
   view.bindingContext[repeat.local] = collection[collectionIndex];
   updateOverrideContext(view.overrideContext, collectionIndex, collection.length);

--- a/src/virtual-repeat.ts
+++ b/src/virtual-repeat.ts
@@ -25,17 +25,12 @@ import {
 import { DOM, PLATFORM } from 'aurelia-pal';
 import { TaskQueue } from 'aurelia-task-queue';
 import {
-  rebindAndMoveView,
-  Math$floor,
-  Math$max,
-  Math$abs,
-  getScrollingState
+  rebindAndMoveView
 } from './utilities';
 import {
   calcOuterHeight,
   getElementDistanceToTopOfDocument,
   hasOverflowScroll,
-  getDistanceToParent,
   calcScrollHeight
 } from './utilities-dom';
 import { VirtualRepeatStrategyLocator } from './virtual-repeat-strategy-locator';
@@ -48,8 +43,7 @@ import {
   IViewSlot,
   IScrollerInfo,
   VirtualizationCalculation,
-  VirtualizationEvents,
-  VirtualiationScrollState
+  VirtualizationEvents
 } from './interfaces';
 import {
   getResizeObserverClass,

--- a/src/virtual-repeat.ts
+++ b/src/virtual-repeat.ts
@@ -91,12 +91,12 @@ export class VirtualRepeat extends AbstractRepeater {
    */
   _first: number = 0;
 
-  /**
-   * Number of views required to fillup the viewport, and also enough to provide smooth scrolling
-   * Without showing blank space
-   * @internal
-   */
-  _viewsLength = 0;
+  // /**
+  //  * Number of views required to fillup the viewport, and also enough to provide smooth scrolling
+  //  * Without showing blank space
+  //  * @internal
+  //  */
+  // _viewsLength: number = 0;
 
   /**
    * Height of top buffer to properly push the visible rendered list items into right position
@@ -285,7 +285,7 @@ export class VirtualRepeat extends AbstractRepeater {
    * Number indicating minimum elements required to render to fill up the visible viewport
    * @internal
    */
-  elementsInView: number;
+  minViewsRequired: number;
 
   /**
    * collection repeating strategy
@@ -560,7 +560,7 @@ export class VirtualRepeat extends AbstractRepeater {
     const scroller = this.getScroller();
     return {
       scroller: scroller,
-      scrollHeight: scroller.scrollHeight,
+      // scrollHeight: scroller.scrollHeight,
       scrollTop: scroller.scrollTop,
       // height: calcScrollHeight(scroller)
       height: scroller === htmlElement
@@ -572,11 +572,11 @@ export class VirtualRepeat extends AbstractRepeater {
   /**@internal */
   _resetCalculation(): void {
     this._first
-      = this._viewsLength
+      // = this._viewsLength
       = this._topBufferHeight
       = this._bottomBufferHeight
       = this.itemHeight
-      = this.elementsInView = 0;
+      = this.minViewsRequired = 0;
     this._ignoreMutation
       = this._handlingMutations
       = this._ticking = false;

--- a/src/virtual-repeat.ts
+++ b/src/virtual-repeat.ts
@@ -28,7 +28,8 @@ import {
   rebindAndMoveView,
   Math$floor,
   Math$max,
-  Math$abs
+  Math$abs,
+  getScrollingState
 } from './utilities';
 import {
   calcOuterHeight,
@@ -47,13 +48,15 @@ import {
   IViewSlot,
   IScrollerInfo,
   VirtualizationCalculation,
-  VirtualizationEvents
+  VirtualizationEvents,
+  VirtualiationScrollState
 } from './interfaces';
 import {
   getResizeObserverClass,
   ResizeObserver,
   DOMRectReadOnly
 } from './resize-observer';
+import { htmlElement } from './constants';
 
 const enum VirtualRepeatCallContext {
   handleCollectionMutated = 'handleCollectionMutated',
@@ -246,6 +249,18 @@ export class VirtualRepeat extends AbstractRepeater {
   _prevItemsCount: number;
 
   /**
+   * Snapshot of previous scroller info. Used to determine action against curr scroller info
+   * @internal
+   */
+  _prevScrollerInfo: IScrollerInfo;
+
+  /**
+   * Snapshot of current scroller info. Used to determine action against previous scroller info
+   * @internal
+   */
+  _currScrollerInfo: IScrollerInfo;
+
+  /**
    * Reference to scrolling container of this virtual repeat
    * Usually determined by template strategy.
    *
@@ -253,9 +268,6 @@ export class VirtualRepeat extends AbstractRepeater {
    * @internal
    */
   scrollerEl: HTMLElement;
-
-  /**@internal */
-  private scrollListener: () => any;
 
   /**@internal */
   _sizeInterval: any;
@@ -267,6 +279,11 @@ export class VirtualRepeat extends AbstractRepeater {
    */
   _calcDistanceToTopInterval: any;
 
+  /**
+   * Defines how many items there should be for a given index to be considered at edge
+   * @internal
+   */
+  edgeDistance: number;
 
   /**
    * Used to revert all checks related to scroll handling guard
@@ -373,6 +390,7 @@ export class VirtualRepeat extends AbstractRepeater {
     this.taskQueue = observerLocator.taskQueue;
     this.strategyLocator = collectionStrategyLocator;
     this.templateStrategyLocator = templateStrategyLocator;
+    this.edgeDistance = 5;
     this.sourceExpression = getItemsSourceExpression(this.instruction, 'virtual-repeat.for');
     this.isOneTime = isOneTime(this.sourceExpression);
     this.itemHeight
@@ -382,6 +400,7 @@ export class VirtualRepeat extends AbstractRepeater {
     this.revertScrollCheckGuard = () => {
       this._ticking = false;
     };
+    this._onScroll = this._onScroll.bind(this);
   }
 
   /**@override */
@@ -396,16 +415,17 @@ export class VirtualRepeat extends AbstractRepeater {
 
     const element = this.element;
     const templateStrategy = this.templateStrategy = this.templateStrategyLocator.getStrategy(element);
-    const scrollListener = this.scrollListener = () => {
-      this._onScroll();
-    };
     const containerEl = this.scrollerEl = templateStrategy.getScrollContainer(element);
     const [topBufferEl, bottomBufferEl] = templateStrategy.createBuffers(element);
     const isFixedHeightContainer = this._fixedHeightContainer = hasOverflowScroll(containerEl);
+    // context bound listener
+    const scrollListener = this._onScroll;
 
     this.topBufferEl = topBufferEl;
     this.bottomBufferEl = bottomBufferEl;
     this.itemsChanged();
+    // take a snapshot of current scrolling information
+    this._currScrollerInfo = this._prevScrollerInfo = this.getScrollerInfo();
 
     if (isFixedHeightContainer) {
       containerEl.addEventListener('scroll', scrollListener);
@@ -427,9 +447,7 @@ export class VirtualRepeat extends AbstractRepeater {
         }
       }, 500);
     }
-    if (this.items.length < this.elementsInView) {
-      this._getMore(/*force?*/true);
-    }
+    this.strategy.onAttached(this);
   }
 
   /**@override */
@@ -440,7 +458,7 @@ export class VirtualRepeat extends AbstractRepeater {
   /**@override */
   detached(): void {
     const scrollCt = this.scrollerEl;
-    const scrollListener = this.scrollListener;
+    const scrollListener = this._onScroll;
     if (hasOverflowScroll(scrollCt)) {
       scrollCt.removeEventListener('scroll', scrollListener);
     } else {
@@ -454,7 +472,7 @@ export class VirtualRepeat extends AbstractRepeater {
     this._unsubscribeCollection();
     this._resetCalculation();
     this.templateStrategy.removeBuffers(this.element, this.topBufferEl, this.bottomBufferEl);
-    this.topBufferEl = this.bottomBufferEl = this.scrollerEl = this.scrollListener = null;
+    this.topBufferEl = this.bottomBufferEl = this.scrollerEl = null;
     this.removeAllViews(/*return to cache?*/true, /*skip animation?*/false);
     const $clearInterval = PLATFORM.global.clearInterval;
     $clearInterval(this._calcDistanceToTopInterval);
@@ -592,7 +610,10 @@ export class VirtualRepeat extends AbstractRepeater {
       scroller: scroller,
       scrollHeight: scroller.scrollHeight,
       scrollTop: scroller.scrollTop,
-      height: calcScrollHeight(scroller)
+      // height: calcScrollHeight(scroller)
+      height: scroller === htmlElement
+        ? innerHeight
+        : calcScrollHeight(scroller)
     };
   }
 
@@ -616,15 +637,19 @@ export class VirtualRepeat extends AbstractRepeater {
       = this._ticking
       = this._isLastIndex = false;
     this._isAtTop = true;
-    this._updateBufferElements(true);
+    this._updateBufferElements(/*skip update?*/true);
   }
 
   /**@internal*/
   _onScroll(): void {
     const isHandlingMutations = this._handlingMutations;
     if (!this._ticking && !isHandlingMutations) {
+      const currentScrollerInfo = this.getScrollerInfo();
+      const prevScrollerInfo = this._currScrollerInfo;
+      this._currScrollerInfo = currentScrollerInfo;
       this.taskQueue.queueMicroTask(() => {
-        this._handleScroll();
+        // this._handleScroll();
+        this._handleScroll2(currentScrollerInfo, prevScrollerInfo);
         this._ticking = false;
       });
       this._ticking = true;
@@ -632,6 +657,245 @@ export class VirtualRepeat extends AbstractRepeater {
 
     if (isHandlingMutations) {
       this._handlingMutations = false;
+    }
+  }
+
+  _scrollState: VirtualiationScrollState;
+
+  /**@internal */
+  _handleScroll2(currentScrollerInfo: IScrollerInfo, prevScrollerInfo: IScrollerInfo): void {
+    if (!this._isAttached) {
+      return;
+    }
+    if (this._skipNextScrollHandle) {
+      this._skipNextScrollHandle = false;
+      return;
+    }
+    const items = this.items;
+    if (!items) {
+      return;
+    }
+
+    const strategy = this.strategy;
+    const old_range_start_index = this._first;
+    const old_range_end_index = this._lastViewIndex();
+    const [new_range_start_index, new_range_end_index] = strategy.getViewRange(this, currentScrollerInfo);
+
+    // treating scrollbar like an axis, we have a few intersection types for two ranges
+    // there are 6 range intersection types (inclusive)
+    // range-1: before scroll (old range)
+    // range-2: after scroll (new range)
+    //
+    // 1: scrolling down not but havent reached bot
+    // range 1: ====[==============]
+    // range-2:     [==============]========
+    //
+    // 2: scrolling up but havent reached top
+    // range-1:        [=======]=========
+    // range-2: =======[=======]
+    //
+    // 3: scrolling down to bottom
+    // range-1: =====[============]
+    // range-2:      [============]
+    //
+    // 4: scrolling up to top
+    // range-1: [===========]======
+    // range-2: [===========]
+    //
+    // 5: jump
+    // range-1: ========
+    // range-2:            ==========
+    //
+    // 6: jump
+    // range-1:            ==========
+    // range-2: ========
+
+    let didMovedViews = 0;
+    let should_call_scroll_next: -1 | 0 | 1 = 0;
+
+    // optimizable case: intersection type 3 & 4
+    // nothing needs to be done. Check these 2 cases in advance to group other logic closer
+    if (
+      // scrolling down and reach bot
+      new_range_start_index >= old_range_start_index && old_range_end_index === new_range_end_index
+      // scrolling up and reach top
+      || new_range_end_index === old_range_end_index && old_range_end_index >= new_range_end_index
+    ) {
+      // do nothing related to updating view. Whatever is going to be visible was already visible
+      // and updated correctly
+      //
+      // start checking whether scrollnext should be invoked
+      // jump down, check if is close to bottom
+      if (new_range_start_index >= old_range_start_index && old_range_end_index === new_range_end_index) {
+        if (strategy.isNearBottom(this, new_range_end_index)) {
+          should_call_scroll_next = 1;
+        }
+      }
+      // jump up. check if near top
+      else if (strategy.isNearTop(this, new_range_start_index)) {
+        should_call_scroll_next = -1;
+      }
+      // return;
+      // todo: fix the issues related to scroll smoothly to bottom not triggering scroll-next
+    } else {
+
+      // intersection type 1: scrolling down but haven't reached bot
+      // needs to move bottom views from old range (range-2) to new range (range-1)
+      if (new_range_start_index > old_range_start_index && old_range_end_index >= new_range_start_index && new_range_end_index >= old_range_end_index) {
+        const views_to_move_count = new_range_start_index - old_range_start_index;
+        this._moveViews2(views_to_move_count, 1);
+        didMovedViews = 1;
+        should_call_scroll_next = 1;
+      }
+      // intersection type 2: scrolling up but haven't reached top
+      // this scenario requires move views from start of old range to end of new range
+      else if (old_range_start_index > new_range_start_index && old_range_start_index <= new_range_end_index && old_range_end_index >= new_range_end_index) {
+        const views_to_move_count = old_range_end_index - new_range_end_index;
+        this._moveViews2(views_to_move_count, -1);
+        didMovedViews = 1;
+        should_call_scroll_next = -1;
+      }
+      // intersection type 5 and type 6: scrolling with jumping behavior
+      // this scenario requires only updating views
+      else if (old_range_end_index < new_range_start_index || old_range_start_index > new_range_end_index) {
+        strategy.remeasure(this);
+        // jump down, check if is close to bottom
+        if (old_range_end_index < new_range_start_index) {
+          if (strategy.isNearBottom(this, new_range_end_index)) {
+            should_call_scroll_next = 1;
+          }
+        }
+        // jump up. check if near top
+        else if (strategy.isNearTop(this, new_range_start_index)) {
+          should_call_scroll_next = -1;
+        }
+      }
+      // catch invalid cases
+      // these are cases that were not handled properly.
+      // If happens, need to fix the above logic related to range check
+      else {
+        strategy.remeasure(this);
+        console.warn('Scroll intersection not handled');
+      }
+    }
+
+    if (didMovedViews === 1) {
+      this._first = new_range_start_index;
+      strategy.updateBuffers(this, new_range_start_index);
+    }
+    // after updating views
+    // check if infinite scrollnext should be invoked
+    // the following block cannot be nested inside didMoveViews condition
+    // since there could be jumpy scrolling behavior causing infinite scrollnext
+    if (should_call_scroll_next !== 0) {
+      this._getMore2(new_range_start_index, strategy.isNearTop(this, new_range_start_index), strategy.isNearBottom(this, new_range_end_index));
+    }
+  }
+
+  /**
+   * Move views based on scrolling direction and number of views to move
+   * Must only be invoked only to move views while scrolling
+   * @internal
+   */
+  _moveViews2(viewsCount: number, direction: /*up*/-1 | /*down*/1): void {
+    const repeat = this;
+    // move to top
+    if (direction === -1) {
+      let startIndex = repeat._firstViewIndex();
+      while (viewsCount--) {
+        const view = repeat._lastView();
+        rebindAndMoveView(
+          repeat,
+          view,
+          --startIndex,
+          /*move to bottom?*/false
+        );
+      }
+    }
+    // move to bottom
+    else {
+      let lastIndex = repeat._lastViewIndex();
+      while (viewsCount--) {
+        const view = repeat.view(0);
+        rebindAndMoveView(
+          repeat,
+          view,
+          ++lastIndex,
+          /*move to bottom?*/true
+        );
+      }
+    }
+  }
+
+  /**@internal*/
+  _getMore2(topIndex: number, isNearTop: boolean, isNearBottom: boolean, force?: boolean): void {
+    if (isNearTop || isNearBottom || force) {
+      // guard against too rapid fire when scrolling towards end/start
+      if (!this._calledGetMore) {
+        const executeGetMore = () => {
+          this._calledGetMore = true;
+          const firstView = this._firstView();
+          const scrollNextAttrName = 'infinite-scroll-next';
+          const func: string | (BindingExpression & { sourceExpression: Expression }) = (firstView
+            && firstView.firstChild
+            && firstView.firstChild.au
+            && firstView.firstChild.au[scrollNextAttrName])
+              ? firstView.firstChild.au[scrollNextAttrName].instruction.attributes[scrollNextAttrName]
+              : undefined;
+          // const topIndex = this._first;
+          // const isAtBottom = this._bottomBufferHeight === 0;
+          // const isAtTop = this._isAtTop;
+
+          if (func === undefined) {
+            // Still reset `_calledGetMore` flag as if it was invoked
+            // though this should not happen as presence of infinite-scroll-next attribute
+            // will make the value at least be an empty string
+            // keeping this logic here for future enhancement/evolution
+            this._calledGetMore = false;
+            return null;
+          } else {
+            const scrollContext: IScrollNextScrollContext = {
+              topIndex: topIndex,
+              isAtBottom: isNearBottom,
+              isAtTop: isNearTop
+            };
+            const overrideContext = this.scope.overrideContext;
+            overrideContext.$scrollContext = scrollContext;
+            if (typeof func === 'string') {
+              const bindingContext = overrideContext.bindingContext;
+              const getMoreFuncName = (firstView.firstChild as Element).getAttribute(scrollNextAttrName);
+              const funcCall = bindingContext[getMoreFuncName];
+
+              if (typeof funcCall === 'function') {
+                const result = funcCall.call(bindingContext, topIndex, isNearBottom, isNearTop);
+                if (!(result instanceof Promise)) {
+                  // Reset for the next time
+                  this._calledGetMore = false;
+                } else {
+                  return result.then(() => {
+                    // Reset for the next time
+                    this._calledGetMore = false;
+                  });
+                }
+              } else {
+                throw new Error(`'${scrollNextAttrName}' must be a function or evaluate to one`);
+              }
+            } else if (func.sourceExpression) {
+              // Reset for the next time
+              this._calledGetMore = false;
+              return func.sourceExpression.evaluate(this.scope);
+            } else {
+              throw new Error(`'${scrollNextAttrName}' must be a function or evaluate to one`);
+            }
+            return null;
+          }
+        };
+
+        // use task so it will be executed before next frame
+        // can help avoid doing double work for handling scroll
+        // in case of mutation
+        requestAnimationFrame(executeGetMore);
+      }
     }
   }
 
@@ -715,7 +979,7 @@ export class VirtualRepeat extends AbstractRepeater {
       this._switchedDirection = false;
       this._topBufferHeight = currentTopBufferHeight + adjustHeight;
       this._bottomBufferHeight = Math$max(currentBottomBufferHeight - adjustHeight, 0);
-      this._updateBufferElements(true);
+      this._updateBufferElements(/*skip update?*/true);
     } else if (this._scrollingUp) {
       const isLastIndex = this._isLastIndex;
       let viewsToMoveCount = currLastReboundIndex - firstIndex;
@@ -741,7 +1005,7 @@ export class VirtualRepeat extends AbstractRepeater {
       this._switchedDirection = false;
       this._topBufferHeight = Math$max(currentTopBufferHeight - adjustHeight, 0);
       this._bottomBufferHeight = currentBottomBufferHeight + adjustHeight;
-      this._updateBufferElements(true);
+      this._updateBufferElements(/*skip update?*/true);
     }
     this._previousFirst = firstIndex;
     this._isScrolling = false;

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -139,6 +139,15 @@ export function validateScroll(virtualRepeat: VirtualRepeat, viewModel: any, ite
   });
 }
 
+export function scrollRepeat(virtualRepeat: VirtualRepeat, dest: 'start' | 'end' | number): void {
+  const scroller = virtualRepeat.getScroller();
+  scroller.scrollTop = dest === 'start'
+    ? 0
+    : dest === 'end'
+      ? scroller.scrollHeight
+      : dest;
+}
+
 /**
  * Scroll a virtual repeat scroller element to top
  */

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -85,7 +85,7 @@ export function validateScrolledState(virtualRepeat: VirtualRepeat, viewModel: I
   }
 
   if (!Array.isArray(viewModel.items) || viewModel.items.length < 0) {
-    expect(virtualRepeat._first).toBe(0, `${extraTitle}repeat._first === 0 <when 0 | null | undefined>`);
+    expect(virtualRepeat.$first).toBe(0, `${extraTitle}repeat._first === 0 <when 0 | null | undefined>`);
     expect(virtualRepeat.viewCount()).toBe(0, `${extraTitle}items.length === 0 | null | undefined`);
     return;
   }
@@ -160,14 +160,14 @@ export async function scrollToStart(virtualRepeat: VirtualRepeat, insuranceTime 
  * Scroll a virtual repeat scroller element to bottom
  */
 export async function scrollToEnd(virtualRepeat: VirtualRepeat, insuranceTime = 5): Promise<void> {
-  let element = virtualRepeat._fixedHeightContainer ? virtualRepeat.scrollerEl : (document.scrollingElement || document.documentElement);
+  let element = virtualRepeat.fixedHeightContainer ? virtualRepeat.scrollerEl : (document.scrollingElement || document.documentElement);
   element.scrollTop = element.scrollHeight;
   createScrollEvent(element);
   await ensureScrolled(insuranceTime);
 }
 
 export async function scrollToIndex(virtualRepeat: VirtualRepeat, itemIndex: number): Promise<void> {
-  let element = virtualRepeat._fixedHeightContainer ? virtualRepeat.scrollerEl : (document.scrollingElement || document.documentElement);
+  let element = virtualRepeat.fixedHeightContainer ? virtualRepeat.scrollerEl : (document.scrollingElement || document.documentElement);
   element.scrollTop = virtualRepeat.itemHeight * (itemIndex + 1);
   createScrollEvent(element);
   await ensureScrolled();

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -160,14 +160,14 @@ export async function scrollToStart(virtualRepeat: VirtualRepeat, insuranceTime 
  * Scroll a virtual repeat scroller element to bottom
  */
 export async function scrollToEnd(virtualRepeat: VirtualRepeat, insuranceTime = 5): Promise<void> {
-  let element = virtualRepeat.fixedHeightContainer ? virtualRepeat.scrollerEl : (document.scrollingElement || document.documentElement);
+  let element = virtualRepeat.scrollerEl;
   element.scrollTop = element.scrollHeight;
   createScrollEvent(element);
   await ensureScrolled(insuranceTime);
 }
 
 export async function scrollToIndex(virtualRepeat: VirtualRepeat, itemIndex: number): Promise<void> {
-  let element = virtualRepeat.fixedHeightContainer ? virtualRepeat.scrollerEl : (document.scrollingElement || document.documentElement);
+  let element = virtualRepeat.scrollerEl;
   element.scrollTop = virtualRepeat.itemHeight * (itemIndex + 1);
   createScrollEvent(element);
   await ensureScrolled();

--- a/test/virtual-repeat-integration.spec.ts
+++ b/test/virtual-repeat-integration.spec.ts
@@ -324,7 +324,7 @@ describe('vr-integration.spec.ts', () => {
 
   describe('value converters', () => {
     let component;
-    let virtualRepeat;
+    let virtualRepeat: VirtualRepeat;
     let viewModel;
     let create;
     let items;

--- a/test/virtual-repeat-integration.spec.ts
+++ b/test/virtual-repeat-integration.spec.ts
@@ -296,13 +296,12 @@ describe('vr-integration.spec.ts', () => {
       });
     });
 
-    it('handles scrolling to bottom', done => {
-      containerCreate.then(() => {
-        validateScroll(containerVirtualRepeat, containerViewModel, () => {
-          expect(containerVirtualRepeat._onScroll).toHaveBeenCalled();
-          done();
-        }, 'scrollContainer2');
-      });
+    it('does not invoke _onScroll after attached()', async done => {
+      await containerCreate;
+      validateScroll(containerVirtualRepeat, containerViewModel, () => {
+        expect(containerVirtualRepeat._onScroll).not.toHaveBeenCalled();
+        done();
+      }, 'scrollContainer2');
     });
 
     it('handles array changes', done => {

--- a/test/virtual-repeat-integration.table.spec.ts
+++ b/test/virtual-repeat-integration.table.spec.ts
@@ -43,7 +43,9 @@ describe('vr-integration.table.spec.ts', () => {
 
   describe('<tr virtual-repeat.for>', () => {
     beforeEach(() => {
-      view = `<table><tr style="height: ${itemHeight}px;" virtual-repeat.for="item of items"><td>\${item}</td></tr></table>`;
+      view = `<table>
+        <tr style="height: ${itemHeight}px;" virtual-repeat.for="item of items"><td>\${item}</td></tr>
+      </table>`;
     });
 
     it('handles push', async (done) => {
@@ -54,10 +56,6 @@ describe('vr-integration.table.spec.ts', () => {
     it('handles array changes', async done => {
       await bootstrapComponent();
       validateArrayChange(virtualRepeat, viewModel, done);
-    });
-
-    it('works with static row', async done => {
-      done();
     });
   });
 
@@ -145,7 +143,6 @@ describe('vr-integration.table.spec.ts', () => {
           await bootstrapComponent();
           await waitForNextFrame();
 
-          expect(virtualRepeat['fixedHeightContainer']).toBe(true);
           expect(called).toBe(true, 'infinite-scroll-next called()');
           expect(viewModel.getNextPage).toHaveBeenCalledTimes(1);
         });
@@ -171,7 +168,6 @@ describe('vr-integration.table.spec.ts', () => {
           await bootstrapComponent();
           await waitForNextFrame();
 
-          expect(virtualRepeat['fixedHeightContainer']).toBe(true);
           expect(scrollContext).toBeDefined();
           expect(scrollContext.isAtTop).toBe(true);
           expect(scrollContext.isAtBottom).toBe(true, 'Expected is at bottom to be true, recevied:' + scrollContext.isAtBottom);
@@ -196,7 +192,6 @@ describe('vr-integration.table.spec.ts', () => {
 
           await bootstrapComponent();
 
-          expect(virtualRepeat['fixedHeightContainer']).toBe(true);
           expect(viewModel.getNextPage).not.toHaveBeenCalled();
         });
       });

--- a/test/virtual-repeat-integration.table.spec.ts
+++ b/test/virtual-repeat-integration.table.spec.ts
@@ -2,7 +2,7 @@ import './setup';
 import { StageComponent, ComponentTester } from 'aurelia-testing';
 import { PLATFORM } from 'aurelia-pal';
 import { bootstrap } from 'aurelia-bootstrapper';
-import { createAssertionQueue, validateState, AsyncQueue, validateScroll } from './utilities';
+import { createAssertionQueue, validateState, AsyncQueue, validateScroll, waitForNextFrame } from './utilities';
 import { VirtualRepeat } from '../src/virtual-repeat';
 import { IScrollNextScrollContext } from '../src/interfaces';
 
@@ -135,17 +135,18 @@ describe('vr-integration.table.spec.ts', () => {
           viewModel.items = createItems(5);
           viewModel.getNextPage = jasmine.createSpy('getNextPage()').and.callFake(
             (topIndex: number, isAtTop: boolean, isAtBottom: boolean) => {
-              expect(topIndex).toBe(0);
-              expect(isAtTop).toBe(true);
-              expect(isAtBottom).toBe(true);
+              expect(topIndex).toBe(0, 'topIndex === 0');
+              expect(isAtTop).toBe(true, 'isAtTop === true');
+              expect(isAtBottom).toBe(true, 'isAtBottom === true');
               called = true;
             }
           );
 
           await bootstrapComponent();
+          await waitForNextFrame();
 
           expect(virtualRepeat['_fixedHeightContainer']).toBe(true);
-          expect(called).toBe(true);
+          expect(called).toBe(true, 'infinite-scroll-next called()');
           expect(viewModel.getNextPage).toHaveBeenCalledTimes(1);
         });
 
@@ -168,6 +169,7 @@ describe('vr-integration.table.spec.ts', () => {
           });
 
           await bootstrapComponent();
+          await waitForNextFrame();
 
           expect(virtualRepeat['_fixedHeightContainer']).toBe(true);
           expect(scrollContext).toBeDefined();

--- a/test/virtual-repeat-integration.table.spec.ts
+++ b/test/virtual-repeat-integration.table.spec.ts
@@ -145,7 +145,7 @@ describe('vr-integration.table.spec.ts', () => {
           await bootstrapComponent();
           await waitForNextFrame();
 
-          expect(virtualRepeat['_fixedHeightContainer']).toBe(true);
+          expect(virtualRepeat['fixedHeightContainer']).toBe(true);
           expect(called).toBe(true, 'infinite-scroll-next called()');
           expect(viewModel.getNextPage).toHaveBeenCalledTimes(1);
         });
@@ -171,7 +171,7 @@ describe('vr-integration.table.spec.ts', () => {
           await bootstrapComponent();
           await waitForNextFrame();
 
-          expect(virtualRepeat['_fixedHeightContainer']).toBe(true);
+          expect(virtualRepeat['fixedHeightContainer']).toBe(true);
           expect(scrollContext).toBeDefined();
           expect(scrollContext.isAtTop).toBe(true);
           expect(scrollContext.isAtBottom).toBe(true, 'Expected is at bottom to be true, recevied:' + scrollContext.isAtBottom);
@@ -196,7 +196,7 @@ describe('vr-integration.table.spec.ts', () => {
 
           await bootstrapComponent();
 
-          expect(virtualRepeat['_fixedHeightContainer']).toBe(true);
+          expect(virtualRepeat['fixedHeightContainer']).toBe(true);
           expect(viewModel.getNextPage).not.toHaveBeenCalled();
         });
       });

--- a/test/vr-integration.infinite-scroll.spec.ts
+++ b/test/vr-integration.infinite-scroll.spec.ts
@@ -193,7 +193,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       );
 
       await waitForNextFrame();
-      expect(virtualRepeat._viewsLength).toBe(12, 'repeat._viewsLength');
+      expect(virtualRepeat.minViewsRequired).toBe(6, 'repeat.elementsInView');
       expect(spy.calls.count()).toBe(1, '3 items getNextPage() calls');
       // await waitForNextFrame();
       // expect(spy.calls.count()).toBe(1, '3 items - next frame -- getNextPage() calls');
@@ -217,7 +217,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
         $view
       ));
       await waitForNextFrame();
-      expect(virtualRepeat._viewsLength).toBe(12, 'repeat._viewsLength');
+      expect(virtualRepeat.minViewsRequired * 2).toBe(12, 'repeat._viewsLength');
       expect(spy.calls.count()).toBe(1, '4 items getNextPage() calls');
       [firstIndex, isAtBottom, isAtTop] = scrollNextArgs;
       expect(firstIndex).toBe(0, 'scrollNextArgs[0] 2');
@@ -239,7 +239,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
         $view
       ));
       await waitForNextFrame();
-      expect(virtualRepeat._viewsLength).toBe(12, 'repeat._viewsLength');
+      expect(virtualRepeat.minViewsRequired * 2).toBe(12, 'repeat._viewsLength');
       expect(spy.calls.count()).toBe(1, '5 items getNextPage() calls');
       [firstIndex, isAtBottom, isAtTop] = scrollNextArgs;
       expect(firstIndex).toBe(0, 'scrollNextArgs[0] 3');
@@ -261,7 +261,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
         $view
       ));
       await waitForNextFrame();
-      expect(virtualRepeat._viewsLength).toBe(12, 'repeat._viewsLength');
+      expect(virtualRepeat.minViewsRequired * 2).toBe(12, 'repeat._viewsLength');
       expect(spy.calls.count()).toBe(0, '6 items = 0 getNextPage() calls');
       [firstIndex, isAtBottom, isAtTop] = scrollNextArgs;
       expect(firstIndex).toBe(0, 'scrollNextArgs[0] 4');
@@ -295,7 +295,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
         extraResources,
         $view
       );
-      expect(virtualRepeat._viewsLength).toBe(12, 'repeat._viewsLength');
+      expect(virtualRepeat.minViewsRequired * 2).toBe(12, 'repeat._viewsLength');
       expect(spy.calls.count()).toBe(0, 'no getNextPage() calls');
 
       expect(viewModel.items.length).toBe(100, 'items.length 1');
@@ -351,7 +351,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
         $view
       );
       expect(scrollNextArgs).toBe(undefined, 'getNextPage() args[]');
-      expect(virtualRepeat._viewsLength).toBe(12, 'repeat._viewsLength');
+      expect(virtualRepeat.minViewsRequired * 2).toBe(12, 'repeat._viewsLength');
       expect(virtualRepeat.viewCount()).toBe(12, 'repeat.viewCount()');
       expect(spy.calls.count()).toBe(0, 'no getNextPage() calls');
 
@@ -431,7 +431,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       );
 
       expect(scrollNextArgs).toBe(undefined, 'getNextPage() args[]');
-      expect(virtualRepeat._viewsLength).toBe(12, 'repeat._viewsLength');
+      expect(virtualRepeat.minViewsRequired * 2).toBe(12, 'repeat._viewsLength');
       expect(virtualRepeat.viewCount()).toBe(12, 'repeat.viewCount()');
       expect(spy.calls.count()).toBe(0, 'no getNextPage() calls 1');
 

--- a/test/vr-integration.infinite-scroll.spec.ts
+++ b/test/vr-integration.infinite-scroll.spec.ts
@@ -274,7 +274,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
 
     it([
       title,
-      'Initial 30 items',
+      'Initial 100 items',
       ' -- scroll down + get 100 more',
       ' -- wait',
       ' -- scroll up + get 100 more',
@@ -310,9 +310,9 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       expect(viewModel.items.length).toBe(200, 'items.length 2');
       let firstViewIndex = virtualRepeat._firstViewIndex();
       let lastViewIndex = virtualRepeat._lastViewIndex();
-      expect(firstViewIndex).toBeGreaterThanOrEqual(100 - 1 - 5, 'repeat._firstViewIndex() 1');
-      expect(firstViewIndex).toBeLessThan(200 - 1 - 5, 'repeat._firstViewIndex < bottom');
-      expect(lastViewIndex).toBeGreaterThanOrEqual(100 - 1 - 5 + 12, 'repeat._lastViewIndex() 1');
+      expect(firstViewIndex).toBeGreaterThanOrEqual(100 - (5 + 1) * 2, 'repeat._firstViewIndex() 1');
+      expect(firstViewIndex).toBeLessThan(200 - (5 + 1) * 2, 'repeat._firstViewIndex < bottom');
+      expect(lastViewIndex).toBeGreaterThanOrEqual(100, 'repeat._lastViewIndex() 1');
       validateScrolledState(virtualRepeat, viewModel, itemHeight);
 
       scrollRepeat(virtualRepeat, 'start');

--- a/test/vr-integration.infinite-scroll.spec.ts
+++ b/test/vr-integration.infinite-scroll.spec.ts
@@ -308,8 +308,8 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       await waitForFrames(2);
       expect(spy.calls.count()).toBe(1, '@scroll 1 start -> end');
       expect(viewModel.items.length).toBe(200, 'items.length 2');
-      let firstViewIndex = virtualRepeat._firstViewIndex();
-      let lastViewIndex = virtualRepeat._lastViewIndex();
+      let firstViewIndex = virtualRepeat.firstViewIndex();
+      let lastViewIndex = virtualRepeat.lastViewIndex();
       expect(firstViewIndex).toBeGreaterThanOrEqual(100 - (5 + 1) * 2, 'repeat._firstViewIndex() 1');
       expect(firstViewIndex).toBeLessThan(200 - (5 + 1) * 2, 'repeat._firstViewIndex < bottom');
       expect(lastViewIndex).toBeGreaterThanOrEqual(100, 'repeat._lastViewIndex() 1');
@@ -322,8 +322,8 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       await waitForFrames(2);
       expect(spy.calls.count()).toBe(2, '@scroll 2 end -> start');
       expect(viewModel.items.length).toBe(300, 'items.length 3');
-      firstViewIndex = virtualRepeat._firstViewIndex();
-      lastViewIndex = virtualRepeat._lastViewIndex();
+      firstViewIndex = virtualRepeat.firstViewIndex();
+      lastViewIndex = virtualRepeat.lastViewIndex();
       expect(firstViewIndex).toBe(0, 'repeat._firstViewIndex() 2');
       expect(lastViewIndex).toBe(11, 'repeat._lastViewIndex() 2');
       validateScrolledState(virtualRepeat, viewModel, itemHeight);
@@ -365,9 +365,9 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       await waitForFrames(2);
       expect(spy.calls.count()).toBe(1, '@scroll 1 start -> end');
       expect(viewModel.items.length).toBe(100, 'items.length 2');
-      let virtualRepeatFirst = virtualRepeat._first;
-      let firstViewIndex = virtualRepeat._firstViewIndex();
-      let lastViewIndex = virtualRepeat._lastViewIndex();
+      let virtualRepeatFirst = virtualRepeat.$first;
+      let firstViewIndex = virtualRepeat.firstViewIndex();
+      let lastViewIndex = virtualRepeat.lastViewIndex();
       expect(firstViewIndex).toBe(88, 'repeat._firstViewIndex() 1');
       // it depends on some condition, start index will be calculated differently.
       // todo: fix this to have deterministic behavior
@@ -388,9 +388,9 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       await waitForFrames(2);
       expect(spy.calls.count()).toBe(2, '@scroll 2 end -> start');
       expect(viewModel.items.length).toBe(100, 'items.length 3');
-      virtualRepeatFirst = virtualRepeat._first;
-      firstViewIndex = virtualRepeat._firstViewIndex();
-      lastViewIndex = virtualRepeat._lastViewIndex();
+      virtualRepeatFirst = virtualRepeat.$first;
+      firstViewIndex = virtualRepeat.firstViewIndex();
+      lastViewIndex = virtualRepeat.lastViewIndex();
       expect(firstViewIndex).toBe(0, 'repeat._firstViewIndex() 2');
       expect(lastViewIndex).toBe(11, 'repeat._lastViewIndex() 2');
       validateScrolledState(virtualRepeat, viewModel, itemHeight);

--- a/test/vr-integration.instance-changed.spec.ts
+++ b/test/vr-integration.instance-changed.spec.ts
@@ -60,7 +60,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
       const table = (component['host'] as HTMLElement).querySelector('table');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       expect(table.tBodies[0].rows.length).toBe(2 + virtualRepeat._viewsLength); // 2 buffers + 20 rows based on 50 height
 
@@ -68,12 +68,10 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat._viewsLength));
 
       // start more difficult cases
-      const scrollSpy = spyOn(virtualRepeat, '_handleScroll').and.callThrough();
       // 1. mutate scroll state
       table.parentElement.scrollTop = table.parentElement.scrollHeight;
       await ensureScrolled(50);
 
-      expect(scrollSpy).toHaveBeenCalledTimes(1);
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       // when scrolling, the first bound row is calculated differently compared to other scenarios
       // as it can be known exactly what the last process was
@@ -117,7 +115,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
       const table = (component['host'] as HTMLElement).querySelector('table');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       expect(table.tBodies[0].rows.length).toBe(2 + virtualRepeat._viewsLength); // 2 buffers + 20 rows based on 50 height
 
@@ -149,7 +147,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11, 'repeat._first 2');
+      expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -179,7 +177,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
       const table = (component['host'] as HTMLElement).querySelector('table');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       expect(table.tBodies[0].rows.length).toBe(2 + virtualRepeat._viewsLength); // 2 buffers + 20 rows based on 50 height
 
@@ -211,7 +209,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(/*items count*/16 - /*element in views*/11, 'repeat._first 2');
+      expect(virtualRepeat._first).toBe(Math.max(0, /*items count*/16 - /*element in views*/11 * 2), 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -240,7 +238,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
       const table = (component['host'] as HTMLElement).querySelector('table');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       expect(table.tBodies[0].rows.length).toBe(2 + virtualRepeat._viewsLength); // 2 buffers + 20 rows based on 50 height
 
@@ -306,7 +304,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
 
 
       const table = (component['host'] as HTMLElement).querySelector('table');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       expect(table.tBodies[0].rows.length).toBe(2 + virtualRepeat._viewsLength); // 2 buffers + 20 rows based on 50 height
 
@@ -358,7 +356,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
 
 
       const table = (component['host'] as HTMLElement).querySelector('table');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       expect(table.tBodies[0].rows.length).toBe(2 + virtualRepeat._viewsLength, 'elements count 1'); // 2 buffers + 20 rows based on 50 height
 
@@ -418,7 +416,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
       const table = (component['host'] as HTMLElement).querySelector('table');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       // buffers are TR element
       expect(table.tBodies.length).toBe(/*no buffer 2 +*/virtualRepeat._viewsLength, 'table.tBodies.length 1'); // 2 buffers + 20 rows based on 50 height
@@ -470,7 +468,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
       const table = (component['host'] as HTMLElement).querySelector('table');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       // buffers are TR elements
       expect(table.tBodies.length).toBe(/*no buffer 2 +*/virtualRepeat._viewsLength, 'table.tBodies.length 1'); // 2 buffers + 20 rows based on 50 height
@@ -504,7 +502,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11, 'repeat._first 2');
+      expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -531,7 +529,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
       const table = (component['host'] as HTMLElement).querySelector('table');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       // buffers are TR elements
       expect(table.tBodies.length).toBe(/*no buffer 2 +*/virtualRepeat._viewsLength, 'table.tBodies.length 1'); // 2 buffers + 20 rows based on 50 height
@@ -566,7 +564,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11, 'repeat._first 2');
+      expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -611,7 +609,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
       const table = (component['host'] as HTMLElement).querySelector('table');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       // buffers are TR elements
       expect(table.tBodies.length).toBe(/*no buffer 2 +*/virtualRepeat._viewsLength, 'table.tBodies.length'); // 2 buffers + 20 rows based on 50 height
@@ -635,7 +633,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(virtualRepeat._bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight');
 
       viewModel.items = viewModel.items.slice(0).reverse().slice(0, 16);
-      await waitForFrames(1);
+      await waitForFrames(2);
 
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       // buffers are TR elements
@@ -645,7 +643,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(/*items count*/16 - /*element in views*/11, 'repeat._first 2');
+      expect(virtualRepeat._first).toBe(Math.max(0, /*items count*/16 - /*element in views*/11 * 2), 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -669,7 +667,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
       const table = (component['host'] as HTMLElement).querySelector('table');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       // buffers are tr elements
       expect(table.tBodies.length).toBe(/*no buffer 2 +*/virtualRepeat._viewsLength, 'table.tBodies.length 1'); // 2 buffers + 20 rows based on 50 height
@@ -737,7 +735,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
       const table = (component['host'] as HTMLElement).querySelector('table');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       expect(table.tBodies.length).toBe(virtualRepeat._viewsLength, 'elements count 1'); // 2 buffers + 20 rows based on 50 height
 
@@ -788,7 +786,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
       const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       expect(scrollerEl.children.length).toBe(2 + virtualRepeat._viewsLength, 'scrollerEl.children.length 1'); // 2 buffers + 20 rows based on 50 height
 
@@ -840,7 +838,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
       const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       expect(scrollerEl.children.length).toBe(2 + virtualRepeat._viewsLength, 'scrollerEl.children.length 1'); // 2 buffers + 20 rows based on 50 height
 
@@ -872,7 +870,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11, 'repeat._first 2');
+      expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -896,7 +894,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
       const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       expect(scrollerEl.children.length).toBe(2 + virtualRepeat._viewsLength, 'scrollerEl.children.length'); // 2 buffers + 20 rows based on 50 height
 
@@ -928,7 +926,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(/*items count*/16 - /*element in views*/11, 'repeat._first 2');
+      expect(virtualRepeat._first).toBe(Math.max(0, /*items count*/16 - /*element in views*/11 * 2), 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -951,7 +949,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
       const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       expect(scrollerEl.children.length).toBe(2 + virtualRepeat._viewsLength, 'scrollerEl.children.length 1'); // 2 buffers + 20 rows based on 50 height
 
@@ -1017,7 +1015,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
 
 
       const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-      expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+      expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
       expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
       expect(scrollerEl.children.length).toBe(2 + virtualRepeat._viewsLength, 'elements count 1'); // 2 buffers + 20 rows based on 50 height
 
@@ -1086,7 +1084,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
         const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-        expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+        expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
         expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
         expect(scrollerEl.firstElementChild.children.length).toBe(
           2 + virtualRepeat._viewsLength,
@@ -1143,7 +1141,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
         const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-        expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+        expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
         expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
         expect(scrollerEl.firstElementChild.children.length).toBe(
           2 + virtualRepeat._viewsLength,
@@ -1179,7 +1177,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // after instance changed, it restart the "_first" view based on safe number of views
         // this safe number of views is different with the case of no collection size changes
         // this case triggers a scroll event
-        expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11, 'repeat._first 2');
+        expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
         // the following check is based on subtraction of total items count and total views count
         // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -1206,7 +1204,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
         const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-        expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+        expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
         expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
         expect(scrollerEl.firstElementChild.children.length).toBe(
           2 + virtualRepeat._viewsLength,
@@ -1242,7 +1240,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // after instance changed, it restart the "_first" view based on safe number of views
         // this safe number of views is different with the case of no collection size changes
         // this case triggers a scroll event
-        expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11, 'repeat._first 2');
+        expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
         // the following check is based on subtraction of total items count and total views count
         // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -1286,7 +1284,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
         const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-        expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+        expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
         expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
         expect(scrollerEl.firstElementChild.children.length).toBe(
           2 + virtualRepeat._viewsLength,
@@ -1320,7 +1318,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // after instance changed, it restart the "_first" view based on safe number of views
         // this safe number of views is different with the case of no collection size changes
         // this case triggers a scroll event
-        expect(virtualRepeat._first).toBe(/*items count*/16 - /*element in views*/11, 'repeat._first 2');
+        expect(virtualRepeat._first).toBe(Math.max(0, /*items count*/16 - /*element in views*/11 * 2), 'repeat._first 2');
 
         // the following check is based on subtraction of total items count and total views count
         // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -1344,7 +1342,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
         const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-        expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+        expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
         expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
         expect(scrollerEl.firstElementChild.children.length).toBe(
           2 + virtualRepeat._viewsLength,
@@ -1413,7 +1411,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
         const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-        expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+        expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
         expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
         expect(scrollerEl.firstElementChild.children.length).toBe(
           2 + virtualRepeat._viewsLength,
@@ -1486,7 +1484,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
         const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-        expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+        expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
         expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
         expect(scrollerEl.children.length).toBe(2 + virtualRepeat._viewsLength, 'scrollerEl.children.length 1'); // 2 buffers + 20 rows based on 50 height
 
@@ -1542,7 +1540,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
         const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-        expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+        expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
         expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
         expect(scrollerEl.children.length).toBe(2 + virtualRepeat._viewsLength, 'scrollerEl.children.length 1'); // 2 buffers + 20 rows based on 50 height
 
@@ -1574,7 +1572,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // after instance changed, it restart the "_first" view based on safe number of views
         // this safe number of views is different with the case of no collection size changes
         // this case triggers a scroll event
-        expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11, 'repeat._first 2');
+        expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
         // the following check is based on subtraction of total items count and total views count
         // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -1617,7 +1615,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
         const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-        expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+        expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
         expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
         expect(scrollerEl.children.length).toBe(2 + virtualRepeat._viewsLength, 'scrollerEl.children.length 1'); // 2 buffers + 20 rows based on 50 height
 
@@ -1649,7 +1647,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // after instance changed, it restart the "_first" view based on safe number of views
         // this safe number of views is different with the case of no collection size changes
         // this case triggers a scroll event
-        expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11, 'repeat._first 2');
+        expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
         // the following check is based on subtraction of total items count and total views count
         // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -1674,7 +1672,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
         const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-        expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+        expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
         expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
         expect(scrollerEl.children.length).toBe(2 + virtualRepeat._viewsLength, 'scrollerEl.children.length'); // 2 buffers + 20 rows based on 50 height
 
@@ -1706,7 +1704,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // after instance changed, it restart the "_first" view based on safe number of views
         // this safe number of views is different with the case of no collection size changes
         // this case triggers a scroll event
-        expect(virtualRepeat._first).toBe(/*items count*/16 - /*element in views*/11, 'repeat._first 2');
+        expect(virtualRepeat._first).toBe(Math.max(0, /*items count*/16 - /*element in views*/11 * 2), 'repeat._first 2');
 
         // the following check is based on subtraction of total items count and total views count
         // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -1730,7 +1728,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
         const scrollerEl = (component['host'] as HTMLElement).querySelector('.scroller');
-        expect(virtualRepeat.elementsInView).toBe(Math.ceil(500 / 50) + 1, 'repeat.elementsInView');
+        expect(virtualRepeat.elementsInView).toBe(Math.floor(500 / 50) + 1, 'repeat.elementsInView');
         expect(virtualRepeat._viewsLength).toBe(22, 'repeat._viewsLength');
         expect(scrollerEl.children.length).toBe(2 + virtualRepeat._viewsLength, 'scrollerEl.children.length 1'); // 2 buffers + 20 rows based on 50 height
 

--- a/test/vr-integration.instance-changed.spec.ts
+++ b/test/vr-integration.instance-changed.spec.ts
@@ -64,8 +64,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(virtualRepeat.minViewsRequired * 2).toBe(22, 'repeat._viewsLength');
       expect(table.tBodies[0].rows.length).toBe(2 + virtualRepeat.minViewsRequired * 2); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
       // start more difficult cases
       // 1. mutate scroll state
@@ -76,11 +76,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // when scrolling, the first bound row is calculated differently compared to other scenarios
       // as it can be known exactly what the last process was
       // so it can create views with optimal number (scroll container height / itemHeight)
-      expect(virtualRepeat._first).toBe(
+      expect(virtualRepeat.$first).toBe(
         /*items count*/100 - calcMaxViewsRequired(500, 50),
         'repeat._first 1'
       );
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
       viewModel.items = viewModel.items.slice(0).reverse();
       await ensureScrolled(0);
@@ -89,16 +89,16 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(table.tBodies[0].rows.length).toBe(2 + virtualRepeat.minViewsRequired * 2, 'table > tr count'); // 2 buffers + 20 rows based on 50 height
       // This check is different from the above:
       // after instance changed, it restart the "_first" view based on safe number of views
-      expect(virtualRepeat._first).toBe(/*items count*/100 - /*views count*/virtualRepeat.minViewsRequired * 2, 'repeat._first 2');
+      expect(virtualRepeat.$first).toBe(/*items count*/100 - /*views count*/virtualRepeat.minViewsRequired * 2, 'repeat._first 2');
 
-      for (let i = 0, ii = viewModel.items.length - virtualRepeat._first; ii > i; ++i) {
+      for (let i = 0, ii = viewModel.items.length - virtualRepeat.$first; ii > i; ++i) {
         const view = virtualRepeat.view(i);
-        const currIndex = i + virtualRepeat._first;
+        const currIndex = i + virtualRepeat.$first;
         expect(view).not.toBeNull(`view-${i} !== null`);
         expect(view.bindingContext.item).toBe(`item${viewModel.items.length - currIndex - 1}`, `view[${i}].bindingContext.item`);
         expect((view.firstChild as Element).firstElementChild.textContent).toBe(`item${viewModel.items.length - currIndex - 1}`);
       }
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
     });
 
     // In this test, it bootstraps a stage with 100 items
@@ -119,8 +119,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(virtualRepeat.minViewsRequired * 2).toBe(22, 'repeat._viewsLength');
       expect(table.tBodies[0].rows.length).toBe(2 + virtualRepeat.minViewsRequired * 2); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
       // start more difficult cases
 
@@ -131,11 +131,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // when scrolling, the first bound row is calculated differently compared to other scenarios
       // as it can be known exactly what the last process was
       // so it can create views with optimal number (scroll container height / itemHeight)
-      expect(virtualRepeat._first).toBe(
+      expect(virtualRepeat.$first).toBe(
         /*items count*/100 - calcMaxViewsRequired(500, 50),
         'repeat._first 1'
       );
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
       viewModel.items = viewModel.items.slice(0).reverse().slice(0, 30);
       await ensureScrolled(50);
@@ -147,7 +147,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
+      expect(virtualRepeat.$first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -159,7 +159,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
         expect((view.firstChild as Element).firstElementChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
       }
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
     });
 
     // In this test, it bootstraps a stage with 100 items
@@ -181,8 +181,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(virtualRepeat.minViewsRequired * 2).toBe(22, 'repeat._viewsLength');
       expect(table.tBodies[0].rows.length).toBe(2 + virtualRepeat.minViewsRequired * 2); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
       // start more difficult cases
 
@@ -193,11 +193,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // when scrolling, the first bound row is calculated differently compared to other scenarios
       // as it can be known exactly what the last process was
       // so it can create views with optimal number (scroll container height / itemHeight)
-      expect(virtualRepeat._first).toBe(
+      expect(virtualRepeat.$first).toBe(
         /*items count*/100 - calcMaxViewsRequired(500, 50),
         'repeat._first 1'
       );
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
       viewModel.items = viewModel.items.slice(0).reverse().slice(0, 16);
       await ensureScrolled(50);
@@ -209,7 +209,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(Math.max(0, /*items count*/16 - /*element in views*/11 * 2), 'repeat._first 2');
+      expect(virtualRepeat.$first).toBe(Math.max(0, /*items count*/16 - /*element in views*/11 * 2), 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -221,7 +221,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
         expect((view.firstChild as Element).firstElementChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
       }
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
     });
 
     // In this test, it bootstraps a stage with 100 items
@@ -242,8 +242,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(virtualRepeat.minViewsRequired * 2).toBe(22, 'repeat._viewsLength');
       expect(table.tBodies[0].rows.length).toBe(2 + virtualRepeat.minViewsRequired * 2); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
       // start more difficult cases
 
@@ -254,11 +254,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // when scrolling, the first bound row is calculated differently compared to other scenarios
       // as it can be known exactly what the last process was
       // so it can create views with optimal number (scroll container height / itemHeight)
-      expect(virtualRepeat._first).toBe(
+      expect(virtualRepeat.$first).toBe(
         /*items count*/100 - calcMaxViewsRequired(500, 50),
         'repeat._first 1'
       );
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
       viewModel.items = viewModel.items.slice(0).reverse().slice(0, 8);
       await ensureScrolled(50);
@@ -270,7 +270,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(0, 'repeat._first 2');
+      expect(virtualRepeat.$first).toBe(0, 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -282,8 +282,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
         expect((view.firstChild as Element).firstElementChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
       }
-      expect(virtualRepeat._topBufferHeight).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.topBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
       expect(virtualRepeat.topBufferEl.getBoundingClientRect().height).toBe(0);
       expect(virtualRepeat.bottomBufferEl.getBoundingClientRect().height).toBe(0);
     });
@@ -308,8 +308,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(virtualRepeat.minViewsRequired * 2).toBe(22, 'repeat._viewsLength');
       expect(table.tBodies[0].rows.length).toBe(2 + virtualRepeat.minViewsRequired * 2); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
       // start more difficult cases
 
@@ -330,7 +330,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       await waitForNextFrame();
       await scrollToEnd(virtualRepeat);
 
-      expect(virtualRepeat._lastViewIndex()).toBe(29, 'repeat._lastViewIndex() 2');
+      expect(virtualRepeat.lastViewIndex()).toBe(29, 'repeat._lastViewIndex() 2');
       expect(scrollerEl.scrollTop).toBe(50 * (30 - 500 / 50), 'scrollerEl.scrollTop 3');
       validateScrolledState(virtualRepeat, viewModel, 50);
       expect(virtualRepeat.bottomBufferEl.style.height).toBe(
@@ -360,8 +360,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(virtualRepeat.minViewsRequired * 2).toBe(22, 'repeat._viewsLength');
       expect(table.tBodies[0].rows.length).toBe(2 + virtualRepeat.minViewsRequired * 2, 'elements count 1'); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
       // start more difficult cases
 
@@ -376,16 +376,16 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       viewModel.items = viewModel.items.slice(0).reverse().slice(0, 11);
       await waitForNextFrame();
 
-      expect(virtualRepeat._lastViewIndex()).toBe(10);
+      expect(virtualRepeat.lastViewIndex()).toBe(10);
       expect(scrollerEl.scrollTop).toBe(50, 'scrollerEl.scrollTop 2');
-      expect(virtualRepeat._bottomBufferHeight).toBe(0, 'repeat._botB-Height 2');
+      expect(virtualRepeat.bottomBufferHeight).toBe(0, 'repeat._botB-Height 2');
       validateScrolledState(virtualRepeat, viewModel, 50);
 
       viewModel.items = createItems(30);
       await waitForNextFrame();
       await scrollToEnd(virtualRepeat);
 
-      expect(virtualRepeat._lastViewIndex()).toBe(29, 'repeat._lastViewIndex() 2');
+      expect(virtualRepeat.lastViewIndex()).toBe(29, 'repeat._lastViewIndex() 2');
       expect(scrollerEl.scrollTop).toBe(50 * (30 - 500 / 50), 'scrollerEl.scrollTop 3');
       validateScrolledState(virtualRepeat, viewModel, 50);
       expect(virtualRepeat.bottomBufferEl.style.height).toBe(
@@ -421,8 +421,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // buffers are TR element
       expect(table.tBodies.length).toBe(virtualRepeat.minViewsRequired * 2, 'table.tBodies.length 1'); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
       // start more difficult cases
 
@@ -433,11 +433,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // when scrolling, the first bound row is calculated differently compared to other scenarios
       // as it can be known exactly what the last process was
       // so it can create views with optimal number (scroll container height / itemHeight)
-      expect(virtualRepeat._first).toBe(
+      expect(virtualRepeat.$first).toBe(
         /*items count*/100 - calcMaxViewsRequired(500, 50),
         'repeat._first 1'
       );
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
       viewModel.items = viewModel.items.slice(0).reverse();
       await ensureScrolled();
@@ -447,16 +447,16 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(table.tBodies.length).toBe(virtualRepeat.minViewsRequired * 2, 'table.tBodies.length 2'); // 2 buffers + 20 rows based on 50 height
       // This check is different from the above:
       // after instance changed, it restart the "_first" view based on safe number of views
-      expect(virtualRepeat._first).toBe(/*items count*/100 - /*views count*/virtualRepeat.minViewsRequired * 2, 'repeat._first 2');
+      expect(virtualRepeat.$first).toBe(/*items count*/100 - /*views count*/virtualRepeat.minViewsRequired * 2, 'repeat._first 2');
 
-      for (let i = 0, ii = viewModel.items.length - virtualRepeat._first; ii > i; ++i) {
+      for (let i = 0, ii = viewModel.items.length - virtualRepeat.$first; ii > i; ++i) {
         const view = virtualRepeat.view(i);
-        const currIndex = i + virtualRepeat._first;
+        const currIndex = i + virtualRepeat.$first;
         expect(view).not.toBeNull(`view-${i} !== null`);
         expect(view.bindingContext.item).toBe(`item${viewModel.items.length - currIndex - 1}`);
         expect((view.firstChild as Element).firstElementChild.firstElementChild.textContent).toBe(`item${viewModel.items.length - currIndex - 1}`);
       }
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
     });
 
     it([
@@ -473,8 +473,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // buffers are TR elements
       expect(table.tBodies.length).toBe(virtualRepeat.minViewsRequired * 2, 'table.tBodies.length 1'); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2), 'repeat._bottomBufferHeight');
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2), 'repeat._bottomBufferHeight');
 
       // start more difficult cases
 
@@ -485,11 +485,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // when scrolling, the first bound row is calculated differently compared to other scenarios
       // as it can be known exactly what the last process was
       // so it can create views with optimal number (scroll container height / itemHeight)
-      expect(virtualRepeat._first).toBe(
+      expect(virtualRepeat.$first).toBe(
         /*items count*/100 - calcMaxViewsRequired(500, 50),
         'repeat._first 1'
       );
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
       viewModel.items = viewModel.items.slice(0).reverse().slice(0, 30);
       await ensureScrolled(50);
@@ -502,7 +502,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
+      expect(virtualRepeat.$first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -514,7 +514,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
         expect((view.firstChild as Element).firstElementChild.firstElementChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
       }
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
     });
 
     it([
@@ -534,8 +534,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // buffers are TR elements
       expect(table.tBodies.length).toBe(virtualRepeat.minViewsRequired * 2, 'table.tBodies.length 1'); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2), 'repeat._bottomBufferHeight');
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2), 'repeat._bottomBufferHeight');
 
       // start more difficult cases
 
@@ -547,11 +547,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // when scrolling, the first bound row is calculated differently compared to other scenarios
       // as it can be known exactly what the last process was
       // so it can create views with optimal number (scroll container height / itemHeight)
-      expect(virtualRepeat._first).toBe(
+      expect(virtualRepeat.$first).toBe(
         /*items count*/100 - calcMaxViewsRequired(500, 50),
         'repeat._first 1'
       );
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
       viewModel.items = viewModel.items.slice(0).reverse().slice(0, 30);
       await ensureScrolled(50);
@@ -564,7 +564,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
+      expect(virtualRepeat.$first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -576,14 +576,14 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
         expect((view.firstChild as Element).firstElementChild.firstElementChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
       }
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
       viewModel.items = null;
       await waitForNextFrame();
       expect(virtualRepeat.minViewsRequired * 2).toBe(0, 'repeat._viewsLength [null]');
       expect(table.tBodies.length).toBe(0, 'table.tBodies.length [null]');
-      expect(virtualRepeat._topBufferHeight).toBe(0, 'repeat._topBufferHeight [null]');
-      expect(virtualRepeat._bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight [null]');
+      expect(virtualRepeat.topBufferHeight).toBe(0, 'repeat._topBufferHeight [null]');
+      expect(virtualRepeat.bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight [null]');
 
       viewModel.items = createItems(50);
       await waitForNextFrame();
@@ -595,8 +595,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(virtualRepeat.items).toBe(undefined, 'repeat.items [undefined]');
       expect(virtualRepeat.minViewsRequired * 2).toBe(0, 'repeat._viewsLength [undefined]');
       expect(table.tBodies.length).toBe(0, 'table.tBodies.length [undefined]');
-      expect(virtualRepeat._topBufferHeight).toBe(0, 'repeat._topBufferHeight [undefined]');
-      expect(virtualRepeat._bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight [undefined]');
+      expect(virtualRepeat.topBufferHeight).toBe(0, 'repeat._topBufferHeight [undefined]');
+      expect(virtualRepeat.bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight [undefined]');
     });
 
     it([
@@ -614,8 +614,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // buffers are TR elements
       expect(table.tBodies.length).toBe(virtualRepeat.minViewsRequired * 2, 'table.tBodies.length'); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
       // start more difficult cases
 
@@ -626,11 +626,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // when scrolling, the first bound row is calculated differently compared to other scenarios
       // as it can be known exactly what the last process was
       // so it can create views with optimal number (scroll container height / itemHeight)
-      expect(virtualRepeat._first).toBe(
+      expect(virtualRepeat.$first).toBe(
         /*items count*/100 - calcMaxViewsRequired(500, 50),
         'repeat._first 1'
       );
-      expect(virtualRepeat._bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight');
+      expect(virtualRepeat.bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight');
 
       viewModel.items = viewModel.items.slice(0).reverse().slice(0, 16);
       await waitForFrames(2);
@@ -643,7 +643,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(Math.max(0, /*items count*/16 - /*element in views*/11 * 2), 'repeat._first 2');
+      expect(virtualRepeat.$first).toBe(Math.max(0, /*items count*/16 - /*element in views*/11 * 2), 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -655,7 +655,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
         expect((view.firstChild as Element).firstElementChild.firstElementChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
       }
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
     });
 
     it([
@@ -672,8 +672,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // buffers are tr elements
       expect(table.tBodies.length).toBe(virtualRepeat.minViewsRequired * 2, 'table.tBodies.length 1'); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
       // start more difficult cases
 
@@ -684,11 +684,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // when scrolling, the first bound row is calculated differently compared to other scenarios
       // as it can be known exactly what the last process was
       // so it can create views with optimal number (scroll container height / itemHeight)
-      expect(virtualRepeat._first).toBe(
+      expect(virtualRepeat.$first).toBe(
         /*items count*/100 - calcMaxViewsRequired(500, 50),
         'repeat._first 1'
       );
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
       viewModel.items = viewModel.items.slice(0).reverse().slice(0, 8);
       await ensureScrolled(50);
@@ -701,7 +701,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(0, 'repeat._first 2');
+      expect(virtualRepeat.$first).toBe(0, 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -713,8 +713,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
         expect((view.firstChild as Element).firstElementChild.firstElementChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
       }
-      expect(virtualRepeat._topBufferHeight).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.topBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
       expect(virtualRepeat.topBufferEl.getBoundingClientRect().height).toBe(0);
       expect(virtualRepeat.bottomBufferEl.getBoundingClientRect().height).toBe(0);
     });
@@ -739,8 +739,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(virtualRepeat.minViewsRequired * 2).toBe(22, 'repeat._viewsLength');
       expect(table.tBodies.length).toBe(virtualRepeat.minViewsRequired * 2, 'elements count 1'); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
       // start more difficult cases
 
@@ -755,16 +755,16 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       viewModel.items = viewModel.items.slice(0).reverse().slice(0, 11);
       await waitForNextFrame();
 
-      expect(virtualRepeat._lastViewIndex()).toBe(10);
+      expect(virtualRepeat.lastViewIndex()).toBe(10);
       expect(scrollerEl.scrollTop).toBe(50, 'scrollerEl.scrollTop 2');
-      expect(virtualRepeat._bottomBufferHeight).toBe(0, 'repeat._botB-Height 2');
+      expect(virtualRepeat.bottomBufferHeight).toBe(0, 'repeat._botB-Height 2');
       validateScrolledState(virtualRepeat, viewModel, 50);
 
       viewModel.items = createItems(30);
       await waitForNextFrame();
       await scrollToEnd(virtualRepeat);
 
-      expect(virtualRepeat._lastViewIndex()).toBe(29, 'repeat._lastViewIndex() 2');
+      expect(virtualRepeat.lastViewIndex()).toBe(29, 'repeat._lastViewIndex() 2');
       expect(scrollerEl.scrollTop).toBe(50 * (30 - 500 / 50), 'scrollerEl.scrollTop 3');
       validateScrolledState(virtualRepeat, viewModel, 50);
       expect(virtualRepeat.bottomBufferEl.style.height).toBe(
@@ -790,8 +790,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(virtualRepeat.minViewsRequired * 2).toBe(22, 'repeat._viewsLength');
       expect(scrollerEl.children.length).toBe(2 + virtualRepeat.minViewsRequired * 2, 'scrollerEl.children.length 1'); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(
         50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2),
         'repeat._bottomBufferHeight'
       );
@@ -805,11 +805,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // when scrolling, the first bound row is calculated differently compared to other scenarios
       // as it can be known exactly what the last process was
       // so it can create views with optimal number (scroll container height / itemHeight)
-      expect(virtualRepeat._first).toBe(
+      expect(virtualRepeat.$first).toBe(
         /*items count*/100 - calcMaxViewsRequired(500, 50),
         'repeat._first 1'
       );
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
       viewModel.items = viewModel.items.slice(0).reverse();
       await ensureScrolled();
@@ -818,16 +818,16 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(scrollerEl.children.length).toBe(2 + virtualRepeat.minViewsRequired * 2, 'scrollerEl.children.length 2'); // 2 buffers + 20 rows based on 50 height
       // This check is different from the above:
       // after instance changed, it restart the "_first" view based on safe number of views
-      expect(virtualRepeat._first).toBe(/*items count*/100 - /*views count*/virtualRepeat.minViewsRequired * 2, 'repeat._first 2');
+      expect(virtualRepeat.$first).toBe(/*items count*/100 - /*views count*/virtualRepeat.minViewsRequired * 2, 'repeat._first 2');
 
-      for (let i = 0, ii = viewModel.items.length - virtualRepeat._first; ii > i; ++i) {
+      for (let i = 0, ii = viewModel.items.length - virtualRepeat.$first; ii > i; ++i) {
         const view = virtualRepeat.view(i);
-        const currIndex = i + virtualRepeat._first;
+        const currIndex = i + virtualRepeat.$first;
         expect(view).not.toBeNull(`view-${i} !== null`);
         expect(view.bindingContext.item).toBe(`item${viewModel.items.length - currIndex - 1}`);
         expect(view.firstChild.textContent).toBe(`item${viewModel.items.length - currIndex - 1}`);
       }
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
     });
 
     it([
@@ -842,8 +842,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(virtualRepeat.minViewsRequired * 2).toBe(22, 'repeat._viewsLength');
       expect(scrollerEl.children.length).toBe(2 + virtualRepeat.minViewsRequired * 2, 'scrollerEl.children.length 1'); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2), 'repeat._bottomBufferHeight');
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2), 'repeat._bottomBufferHeight');
 
       // start more difficult cases
 
@@ -854,11 +854,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // when scrolling, the first bound row is calculated differently compared to other scenarios
       // as it can be known exactly what the last process was
       // so it can create views with optimal number (scroll container height / itemHeight)
-      expect(virtualRepeat._first).toBe(
+      expect(virtualRepeat.$first).toBe(
         /*items count*/100 - calcMaxViewsRequired(500, 50),
         'repeat._first 1'
       );
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
       viewModel.items = viewModel.items.slice(0).reverse().slice(0, 30);
       await ensureScrolled(50);
@@ -870,7 +870,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
+      expect(virtualRepeat.$first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -882,7 +882,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
         expect(view.firstChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
       }
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
     });
 
     it([
@@ -898,8 +898,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(virtualRepeat.minViewsRequired * 2).toBe(22, 'repeat._viewsLength');
       expect(scrollerEl.children.length).toBe(2 + virtualRepeat.minViewsRequired * 2, 'scrollerEl.children.length'); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
       // start more difficult cases
 
@@ -910,11 +910,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // when scrolling, the first bound row is calculated differently compared to other scenarios
       // as it can be known exactly what the last process was
       // so it can create views with optimal number (scroll container height / itemHeight)
-      expect(virtualRepeat._first).toBe(
+      expect(virtualRepeat.$first).toBe(
         /*items count*/100 - calcMaxViewsRequired(500, 50),
         'repeat._first 1'
       );
-      expect(virtualRepeat._bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight');
+      expect(virtualRepeat.bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight');
 
       viewModel.items = viewModel.items.slice(0).reverse().slice(0, 16);
       await ensureScrolled(50);
@@ -926,7 +926,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(Math.max(0, /*items count*/16 - /*element in views*/11 * 2), 'repeat._first 2');
+      expect(virtualRepeat.$first).toBe(Math.max(0, /*items count*/16 - /*element in views*/11 * 2), 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -938,7 +938,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
         expect(view.firstChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
       }
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
     });
 
     it([
@@ -953,8 +953,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(virtualRepeat.minViewsRequired * 2).toBe(22, 'repeat._viewsLength');
       expect(scrollerEl.children.length).toBe(2 + virtualRepeat.minViewsRequired * 2, 'scrollerEl.children.length 1'); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
       // start more difficult cases
 
@@ -965,11 +965,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // when scrolling, the first bound row is calculated differently compared to other scenarios
       // as it can be known exactly what the last process was
       // so it can create views with optimal number (scroll container height / itemHeight)
-      expect(virtualRepeat._first).toBe(
+      expect(virtualRepeat.$first).toBe(
         /*items count*/100 - calcMaxViewsRequired(500, 50),
         'repeat._first 1'
       );
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
       viewModel.items = viewModel.items.slice(0).reverse().slice(0, 8);
       await ensureScrolled(50);
@@ -981,7 +981,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       // after instance changed, it restart the "_first" view based on safe number of views
       // this safe number of views is different with the case of no collection size changes
       // this case triggers a scroll event
-      expect(virtualRepeat._first).toBe(0, 'repeat._first 2');
+      expect(virtualRepeat.$first).toBe(0, 'repeat._first 2');
 
       // the following check is based on subtraction of total items count and total views count
       // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -993,8 +993,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
         expect(view.firstChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
       }
-      expect(virtualRepeat._topBufferHeight).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(0);
+      expect(virtualRepeat.topBufferHeight).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(0);
       expect(virtualRepeat.topBufferEl.getBoundingClientRect().height).toBe(0);
       expect(virtualRepeat.bottomBufferEl.getBoundingClientRect().height).toBe(0);
     });
@@ -1019,8 +1019,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       expect(virtualRepeat.minViewsRequired * 2).toBe(22, 'repeat._viewsLength');
       expect(scrollerEl.children.length).toBe(2 + virtualRepeat.minViewsRequired * 2, 'elements count 1'); // 2 buffers + 20 rows based on 50 height
 
-      expect(virtualRepeat._first).toBe(0);
-      expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+      expect(virtualRepeat.$first).toBe(0);
+      expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
       // start more difficult cases
 
@@ -1034,16 +1034,16 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       viewModel.items = viewModel.items.slice(0).reverse().slice(0, 11);
       await waitForNextFrame();
 
-      expect(virtualRepeat._lastViewIndex()).toBe(10);
+      expect(virtualRepeat.lastViewIndex()).toBe(10);
       expect(scrollerEl.scrollTop).toBe(50, 'scrollerEl.scrollTop 2');
-      expect(virtualRepeat._bottomBufferHeight).toBe(0, 'repeat._botB-Height 2');
+      expect(virtualRepeat.bottomBufferHeight).toBe(0, 'repeat._botB-Height 2');
       validateScrolledState(virtualRepeat, viewModel, 50);
 
       viewModel.items = createItems(30);
       await waitForNextFrame();
       await scrollToEnd(virtualRepeat);
 
-      expect(virtualRepeat._lastViewIndex()).toBe(29, 'repeat._lastViewIndex() 2');
+      expect(virtualRepeat.lastViewIndex()).toBe(29, 'repeat._lastViewIndex() 2');
       expect(scrollerEl.scrollTop).toBe(50 * (30 - 500 / 50), 'scrollerEl.scrollTop 3');
       validateScrolledState(virtualRepeat, viewModel, 50);
       expect(virtualRepeat.bottomBufferEl.style.height).toBe(
@@ -1090,8 +1090,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           2 + virtualRepeat.minViewsRequired * 2,
           'scrollerEl.children.length 1'); // 2 buffers + 20 rows based on 50 height
 
-        expect(virtualRepeat._first).toBe(0);
-        expect(virtualRepeat._bottomBufferHeight).toBe(
+        expect(virtualRepeat.$first).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(
           50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2),
           'repeat._bottomBufferHeight'
         );
@@ -1105,11 +1105,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // when scrolling, the first bound row is calculated differently compared to other scenarios
         // as it can be known exactly what the last process was
         // so it can create views with optimal number (scroll container height / itemHeight)
-        expect(virtualRepeat._first).toBe(
+        expect(virtualRepeat.$first).toBe(
           /*items count*/100 - calcMaxViewsRequired(500, 50),
           'repeat._first 1'
         );
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
         viewModel.items = viewModel.items.slice(0).reverse();
         await ensureScrolled();
@@ -1120,16 +1120,16 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           'scrollerEl.children.length 2'); // 2 buffers + 20 rows based on 50 height
         // This check is different from the above:
         // after instance changed, it restart the "_first" view based on safe number of views
-        expect(virtualRepeat._first).toBe(/*items count*/100 - /*views count*/virtualRepeat.minViewsRequired * 2, 'repeat._first 2');
+        expect(virtualRepeat.$first).toBe(/*items count*/100 - /*views count*/virtualRepeat.minViewsRequired * 2, 'repeat._first 2');
 
-        for (let i = 0, ii = viewModel.items.length - virtualRepeat._first; ii > i; ++i) {
+        for (let i = 0, ii = viewModel.items.length - virtualRepeat.$first; ii > i; ++i) {
           const view = virtualRepeat.view(i);
-          const currIndex = i + virtualRepeat._first;
+          const currIndex = i + virtualRepeat.$first;
           expect(view).not.toBeNull(`view-${i} !== null`);
           expect(view.bindingContext.item).toBe(`item${viewModel.items.length - currIndex - 1}`);
           expect(view.firstChild.textContent).toBe(`item${viewModel.items.length - currIndex - 1}`);
         }
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
       });
 
       it([
@@ -1147,8 +1147,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           2 + virtualRepeat.minViewsRequired * 2,
           'scrollerEl.children.length 1'); // 2 buffers + 20 rows based on 50 height
 
-        expect(virtualRepeat._first).toBe(0);
-        expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2), 'repeat._bottomBufferHeight');
+        expect(virtualRepeat.$first).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2), 'repeat._bottomBufferHeight');
 
         // start more difficult cases
 
@@ -1159,11 +1159,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // when scrolling, the first bound row is calculated differently compared to other scenarios
         // as it can be known exactly what the last process was
         // so it can create views with optimal number (scroll container height / itemHeight)
-        expect(virtualRepeat._first).toBe(
+        expect(virtualRepeat.$first).toBe(
           /*items count*/100 - calcMaxViewsRequired(500, 50),
           'repeat._first 1'
         );
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
         viewModel.items = viewModel.items.slice(0).reverse().slice(0, 30);
         await ensureScrolled(50);
@@ -1177,7 +1177,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // after instance changed, it restart the "_first" view based on safe number of views
         // this safe number of views is different with the case of no collection size changes
         // this case triggers a scroll event
-        expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
+        expect(virtualRepeat.$first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
         // the following check is based on subtraction of total items count and total views count
         // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -1189,7 +1189,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
           expect(view.firstChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
         }
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
       });
 
       it([
@@ -1210,8 +1210,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           2 + virtualRepeat.minViewsRequired * 2,
           'scrollerEl.children.length 1'); // 2 buffers + 20 rows based on 50 height
 
-        expect(virtualRepeat._first).toBe(0);
-        expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2), 'repeat._bottomBufferHeight');
+        expect(virtualRepeat.$first).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2), 'repeat._bottomBufferHeight');
 
         // start more difficult cases
 
@@ -1222,11 +1222,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // when scrolling, the first bound row is calculated differently compared to other scenarios
         // as it can be known exactly what the last process was
         // so it can create views with optimal number (scroll container height / itemHeight)
-        expect(virtualRepeat._first).toBe(
+        expect(virtualRepeat.$first).toBe(
           /*items count*/100 - calcMaxViewsRequired(500, 50),
           'repeat._first 1'
         );
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
         viewModel.items = viewModel.items.slice(0).reverse().slice(0, 30);
         await ensureScrolled(50);
@@ -1240,7 +1240,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // after instance changed, it restart the "_first" view based on safe number of views
         // this safe number of views is different with the case of no collection size changes
         // this case triggers a scroll event
-        expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
+        expect(virtualRepeat.$first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
         // the following check is based on subtraction of total items count and total views count
         // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -1252,14 +1252,14 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
           expect(view.firstChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
         }
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
         viewModel.items = null;
         await waitForNextFrame();
         expect(virtualRepeat.minViewsRequired * 2).toBe(0, 'repeat._viewsLength [null]');
         expect(scrollerEl.firstElementChild.children.length).toBe(2, 'scrollerEl.firstElementChild.children.length [null]');
-        expect(virtualRepeat._topBufferHeight).toBe(0, 'repeat._topBufferHeight [null]');
-        expect(virtualRepeat._bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight [null]');
+        expect(virtualRepeat.topBufferHeight).toBe(0, 'repeat._topBufferHeight [null]');
+        expect(virtualRepeat.bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight [null]');
 
         viewModel.items = createItems(50);
         await waitForNextFrame();
@@ -1270,8 +1270,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         expect(virtualRepeat.items).toBe(undefined, 'repeat.items [undefined]');
         expect(virtualRepeat.minViewsRequired * 2).toBe(0, 'repeat._viewsLength [undefined]');
         expect(scrollerEl.firstElementChild.children.length).toBe(2, 'scrollerEl.firstElementChild.children.length [undefined]');
-        expect(virtualRepeat._topBufferHeight).toBe(0, 'repeat._topBufferHeight [undefined]');
-        expect(virtualRepeat._bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight [undefined]');
+        expect(virtualRepeat.topBufferHeight).toBe(0, 'repeat._topBufferHeight [undefined]');
+        expect(virtualRepeat.bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight [undefined]');
       });
 
       it([
@@ -1290,8 +1290,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           2 + virtualRepeat.minViewsRequired * 2,
           'scrollerEl.children.length'); // 2 buffers + 20 rows based on 50 height
 
-        expect(virtualRepeat._first).toBe(0);
-        expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+        expect(virtualRepeat.$first).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
         // start more difficult cases
 
@@ -1302,11 +1302,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // when scrolling, the first bound row is calculated differently compared to other scenarios
         // as it can be known exactly what the last process was
         // so it can create views with optimal number (scroll container height / itemHeight)
-        expect(virtualRepeat._first).toBe(
+        expect(virtualRepeat.$first).toBe(
           /*items count*/100 - calcMaxViewsRequired(500, 50),
           'repeat._first 1'
         );
-        expect(virtualRepeat._bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight');
+        expect(virtualRepeat.bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight');
 
         viewModel.items = viewModel.items.slice(0).reverse().slice(0, 16);
         await ensureScrolled(50);
@@ -1318,7 +1318,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // after instance changed, it restart the "_first" view based on safe number of views
         // this safe number of views is different with the case of no collection size changes
         // this case triggers a scroll event
-        expect(virtualRepeat._first).toBe(Math.max(0, /*items count*/16 - /*element in views*/11 * 2), 'repeat._first 2');
+        expect(virtualRepeat.$first).toBe(Math.max(0, /*items count*/16 - /*element in views*/11 * 2), 'repeat._first 2');
 
         // the following check is based on subtraction of total items count and total views count
         // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -1330,7 +1330,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
           expect(view.firstChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
         }
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
       });
 
       it([
@@ -1349,8 +1349,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           'scrollerEl.children.length 1'
         ); // 2 buffers + 20 rows based on 50 height
 
-        expect(virtualRepeat._first).toBe(0);
-        expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+        expect(virtualRepeat.$first).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
         // start more difficult cases
 
@@ -1361,11 +1361,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // when scrolling, the first bound row is calculated differently compared to other scenarios
         // as it can be known exactly what the last process was
         // so it can create views with optimal number (scroll container height / itemHeight)
-        expect(virtualRepeat._first).toBe(
+        expect(virtualRepeat.$first).toBe(
           /*items count*/100 - calcMaxViewsRequired(500, 50),
           'repeat._first 1'
         );
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
         viewModel.items = viewModel.items.slice(0).reverse().slice(0, 8);
         await ensureScrolled(50);
@@ -1377,7 +1377,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // after instance changed, it restart the "_first" view based on safe number of views
         // this safe number of views is different with the case of no collection size changes
         // this case triggers a scroll event
-        expect(virtualRepeat._first).toBe(0, 'repeat._first 2');
+        expect(virtualRepeat.$first).toBe(0, 'repeat._first 2');
 
         // the following check is based on subtraction of total items count and total views count
         // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -1389,8 +1389,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
           expect(view.firstChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
         }
-        expect(virtualRepeat._topBufferHeight).toBe(0);
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.topBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
         expect(virtualRepeat.topBufferEl.getBoundingClientRect().height).toBe(0);
         expect(virtualRepeat.bottomBufferEl.getBoundingClientRect().height).toBe(0);
       });
@@ -1417,8 +1417,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           2 + virtualRepeat.minViewsRequired * 2,
           'elements count 1'); // 2 buffers + 20 rows based on 50 height
 
-        expect(virtualRepeat._first).toBe(0);
-        expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+        expect(virtualRepeat.$first).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
         // start more difficult cases
 
@@ -1432,10 +1432,10 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         viewModel.items = viewModel.items.slice(0).reverse().slice(0, 11);
         await waitForNextFrame();
 
-        expect(virtualRepeat._firstViewIndex()).toBe(0);
-        expect(virtualRepeat._lastViewIndex()).toBe(10);
+        expect(virtualRepeat.firstViewIndex()).toBe(0);
+        expect(virtualRepeat.lastViewIndex()).toBe(10);
         // expect(scrollerEl.scrollTop).toBe(50, 'scrollerEl.scrollTop 2');
-        expect(virtualRepeat._bottomBufferHeight).toBe(0, 'repeat._botB-Height 2');
+        expect(virtualRepeat.bottomBufferHeight).toBe(0, 'repeat._botB-Height 2');
         validateScrolledState(virtualRepeat, viewModel, 50);
 
         viewModel.items = createItems(30);
@@ -1445,8 +1445,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
 
         await scrollToEnd(virtualRepeat);
 
-        expect(virtualRepeat._firstViewIndex()).toBe(30 - 22, 'repeat._first > 0');
-        expect(virtualRepeat._lastViewIndex()).toBe(29, 'repeat._lastViewIndex() 2');
+        expect(virtualRepeat.firstViewIndex()).toBe(30 - 22, 'repeat._first > 0');
+        expect(virtualRepeat.lastViewIndex()).toBe(29, 'repeat._lastViewIndex() 2');
         expect(scrollerEl.scrollTop).toBe(50 * (30 - 500 / 50), 'scrollerEl.scrollTop 3');
         validateScrolledState(virtualRepeat, viewModel, 50);
         expect(virtualRepeat.bottomBufferEl.style.height).toBe(
@@ -1491,8 +1491,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           'scrollerEl.children.length 1'
         ); // 2 buffers + 20 rows based on 50 height
 
-        expect(virtualRepeat._first).toBe(0);
-        expect(virtualRepeat._bottomBufferHeight).toBe(
+        expect(virtualRepeat.$first).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(
           50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2),
           'repeat._bottomBufferHeight'
         );
@@ -1506,11 +1506,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // when scrolling, the first bound row is calculated differently compared to other scenarios
         // as it can be known exactly what the last process was
         // so it can create views with optimal number (scroll container height / itemHeight)
-        expect(virtualRepeat._first).toBe(
+        expect(virtualRepeat.$first).toBe(
           /*items count*/100 - calcMaxViewsRequired(500, 50),
           'repeat._first 1'
         );
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
         viewModel.items = viewModel.items.slice(0).reverse();
         await ensureScrolled();
@@ -1522,16 +1522,16 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         ); // 2 buffers + 20 rows based on 50 height
         // This check is different from the above:
         // after instance changed, it restart the "_first" view based on safe number of views
-        expect(virtualRepeat._first).toBe(/*items count*/100 - /*views count*/virtualRepeat.minViewsRequired * 2, 'repeat._first 2');
+        expect(virtualRepeat.$first).toBe(/*items count*/100 - /*views count*/virtualRepeat.minViewsRequired * 2, 'repeat._first 2');
 
-        for (let i = 0, ii = viewModel.items.length - virtualRepeat._first; ii > i; ++i) {
+        for (let i = 0, ii = viewModel.items.length - virtualRepeat.$first; ii > i; ++i) {
           const view = virtualRepeat.view(i);
-          const currIndex = i + virtualRepeat._first;
+          const currIndex = i + virtualRepeat.$first;
           expect(view).not.toBeNull(`view-${i} !== null`);
           expect(view.bindingContext.item).toBe(`item${viewModel.items.length - currIndex - 1}`);
           expect(view.firstChild.textContent).toBe(`item${viewModel.items.length - currIndex - 1}`);
         }
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
       });
 
       it([
@@ -1553,8 +1553,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           'scrollerEl.children.length 1'
         ); // 2 buffers + 20 rows based on 50 height
 
-        expect(virtualRepeat._first).toBe(0);
-        expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2), 'repeat._bottomBufferHeight');
+        expect(virtualRepeat.$first).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2), 'repeat._bottomBufferHeight');
 
         // start more difficult cases
 
@@ -1565,11 +1565,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // when scrolling, the first bound row is calculated differently compared to other scenarios
         // as it can be known exactly what the last process was
         // so it can create views with optimal number (scroll container height / itemHeight)
-        expect(virtualRepeat._first).toBe(
+        expect(virtualRepeat.$first).toBe(
           /*items count*/100 - calcMaxViewsRequired(500, 50),
           'repeat._first 1'
         );
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
         viewModel.items = viewModel.items.slice(0).reverse().slice(0, 30);
         await ensureScrolled(50);
@@ -1584,7 +1584,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // after instance changed, it restart the "_first" view based on safe number of views
         // this safe number of views is different with the case of no collection size changes
         // this case triggers a scroll event
-        expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
+        expect(virtualRepeat.$first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
         // the following check is based on subtraction of total items count and total views count
         // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -1596,14 +1596,14 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
           expect(view.firstChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
         }
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
         viewModel.items = null;
         await waitForNextFrame();
         expect(virtualRepeat.minViewsRequired * 2).toBe(0, 'repeat._viewsLength [null]');
         expect(scrollerEl.children.length).toBe(2, 'scrollerEl.children.length [null]');
-        expect(virtualRepeat._topBufferHeight).toBe(0, 'repeat._topBufferHeight [null]');
-        expect(virtualRepeat._bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight [null]');
+        expect(virtualRepeat.topBufferHeight).toBe(0, 'repeat._topBufferHeight [null]');
+        expect(virtualRepeat.bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight [null]');
 
         viewModel.items = createItems(50);
         await waitForNextFrame();
@@ -1614,8 +1614,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         expect(virtualRepeat.items).toBe(undefined, 'repeat.items [undefined]');
         expect(virtualRepeat.minViewsRequired * 2).toBe(0, 'repeat._viewsLength [undefined]');
         expect(scrollerEl.children.length).toBe(2, 'scrollerEl.children.length [undefined]');
-        expect(virtualRepeat._topBufferHeight).toBe(0, 'repeat._topBufferHeight [undefined]');
-        expect(virtualRepeat._bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight [undefined]');
+        expect(virtualRepeat.topBufferHeight).toBe(0, 'repeat._topBufferHeight [undefined]');
+        expect(virtualRepeat.bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight [undefined]');
       });
 
       it([
@@ -1634,8 +1634,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           'scrollerEl.children.length 1'
         ); // 2 buffers + 20 rows based on 50 height
 
-        expect(virtualRepeat._first).toBe(0);
-        expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2), 'repeat._bottomBufferHeight');
+        expect(virtualRepeat.$first).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2), 'repeat._bottomBufferHeight');
 
         // start more difficult cases
 
@@ -1646,11 +1646,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // when scrolling, the first bound row is calculated differently compared to other scenarios
         // as it can be known exactly what the last process was
         // so it can create views with optimal number (scroll container height / itemHeight)
-        expect(virtualRepeat._first).toBe(
+        expect(virtualRepeat.$first).toBe(
           /*items count*/100 - calcMaxViewsRequired(500, 50),
           'repeat._first 1'
         );
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
         viewModel.items = viewModel.items.slice(0).reverse().slice(0, 30);
         await ensureScrolled(50);
@@ -1665,7 +1665,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // after instance changed, it restart the "_first" view based on safe number of views
         // this safe number of views is different with the case of no collection size changes
         // this case triggers a scroll event
-        expect(virtualRepeat._first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
+        expect(virtualRepeat.$first).toBe(/*items count*/30 - /*element in views*/11 * 2, 'repeat._first 2');
 
         // the following check is based on subtraction of total items count and total views count
         // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -1677,7 +1677,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
           expect(view.firstChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
         }
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
       });
 
       it([
@@ -1694,8 +1694,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         expect(virtualRepeat.minViewsRequired * 2).toBe(22, 'repeat._viewsLength');
         expect(scrollerEl.children.length).toBe(2 + virtualRepeat.minViewsRequired * 2, 'scrollerEl.children.length'); // 2 buffers + 20 rows based on 50 height
 
-        expect(virtualRepeat._first).toBe(0);
-        expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+        expect(virtualRepeat.$first).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
         // start more difficult cases
 
@@ -1706,11 +1706,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // when scrolling, the first bound row is calculated differently compared to other scenarios
         // as it can be known exactly what the last process was
         // so it can create views with optimal number (scroll container height / itemHeight)
-        expect(virtualRepeat._first).toBe(
+        expect(virtualRepeat.$first).toBe(
           /*items count*/100 - calcMaxViewsRequired(500, 50),
           'repeat._first 1'
         );
-        expect(virtualRepeat._bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight');
+        expect(virtualRepeat.bottomBufferHeight).toBe(0, 'repeat._bottomBufferHeight');
 
         viewModel.items = viewModel.items.slice(0).reverse().slice(0, 16);
         await ensureScrolled(50);
@@ -1722,7 +1722,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // after instance changed, it restart the "_first" view based on safe number of views
         // this safe number of views is different with the case of no collection size changes
         // this case triggers a scroll event
-        expect(virtualRepeat._first).toBe(Math.max(0, /*items count*/16 - /*element in views*/11 * 2), 'repeat._first 2');
+        expect(virtualRepeat.$first).toBe(Math.max(0, /*items count*/16 - /*element in views*/11 * 2), 'repeat._first 2');
 
         // the following check is based on subtraction of total items count and total views count
         // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -1734,7 +1734,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
           expect(view.firstChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
         }
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
       });
 
       it([
@@ -1753,8 +1753,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           'scrollerEl.children.length 1'
         ); // 2 buffers + 20 rows based on 50 height
 
-        expect(virtualRepeat._first).toBe(0);
-        expect(virtualRepeat._bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
+        expect(virtualRepeat.$first).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(50 * (virtualRepeat.items.length - virtualRepeat.minViewsRequired * 2));
 
         // start more difficult cases
 
@@ -1765,11 +1765,11 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // when scrolling, the first bound row is calculated differently compared to other scenarios
         // as it can be known exactly what the last process was
         // so it can create views with optimal number (scroll container height / itemHeight)
-        expect(virtualRepeat._first).toBe(
+        expect(virtualRepeat.$first).toBe(
           /*items count*/100 - calcMaxViewsRequired(500, 50),
           'repeat._first 1'
         );
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
 
         viewModel.items = viewModel.items.slice(0).reverse().slice(0, 8);
         await ensureScrolled(50);
@@ -1781,7 +1781,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         // after instance changed, it restart the "_first" view based on safe number of views
         // this safe number of views is different with the case of no collection size changes
         // this case triggers a scroll event
-        expect(virtualRepeat._first).toBe(0, 'repeat._first 2');
+        expect(virtualRepeat.$first).toBe(0, 'repeat._first 2');
 
         // the following check is based on subtraction of total items count and total views count
         // as total number of views hasn't been changed, and their binding contexts created by [repeat]
@@ -1793,8 +1793,8 @@ describe('vr-integration.instance-changed.spec.ts', () => {
           expect(view.bindingContext.item).toBe(`item${100 - currIndex - 1}`, 'bindingContext.item');
           expect(view.firstChild.textContent).toBe(`item${100 - currIndex - 1}`, 'row.textContent');
         }
-        expect(virtualRepeat._topBufferHeight).toBe(0);
-        expect(virtualRepeat._bottomBufferHeight).toBe(0);
+        expect(virtualRepeat.topBufferHeight).toBe(0);
+        expect(virtualRepeat.bottomBufferHeight).toBe(0);
         expect(virtualRepeat.topBufferEl.getBoundingClientRect().height).toBe(0);
         expect(virtualRepeat.bottomBufferEl.getBoundingClientRect().height).toBe(0);
       });

--- a/test/vr-integration.instance-mutated.spec.ts
+++ b/test/vr-integration.instance-mutated.spec.ts
@@ -240,7 +240,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       expect(virtualRepeat.items.length).toEqual(24, 'virtualRepeat.items.length');
       expect(virtualRepeat.element.parentElement.scrollHeight).toEqual(100 * 24, 'scrollHeight 2');
       expect(virtualRepeat.element.parentElement.scrollTop).toEqual(100 * (24 - 5), 'scrollTop 2');
-      expect(virtualRepeat._first).toBe(1000 - (1000 - virtualRepeat.minViewsRequired * 2), 'virtualRepeat._first 1');
+      expect(virtualRepeat.$first).toBe(1000 - (1000 - virtualRepeat.minViewsRequired * 2), 'virtualRepeat._first 1');
       validateScrolledState(virtualRepeat, viewModel, itemHeight);
     });
 
@@ -329,7 +329,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       await waitForNextFrame();
       expect(scrollCount).toBe(1, '@scroll 1');
       expect(virtualRepeat.element.parentElement.scrollTop).toBe(100 * 995, 'anchor.parent.scrollTop 1');
-      expect(virtualRepeat._first).toBe(988, 'repeat._first 1');
+      expect(virtualRepeat.$first).toBe(988, 'repeat._first 1');
 
       viewModel.items.splice(5, 990, {}, {});
       const hasValueConverter = extraResources.length > 0;
@@ -338,18 +338,18 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
         expect(virtualRepeat.element.parentElement.scrollHeight).toBe(100 * 12, '| vc >> scroller.scrollHeight 2');
         expect(virtualRepeat.element.parentElement.scrollTop).toBe(100 * (12 - 500 / 100), '| vc >> scroller.scrollTop 2');
         expect(scrollCount).toBeGreaterThanOrEqual(2, '| vc >> @scroll 3');
-        expect(virtualRepeat._first).toBe(0, '| vc >> repeat._first 2');
+        expect(virtualRepeat.$first).toBe(0, '| vc >> repeat._first 2');
         validateScrolledState(virtualRepeat, viewModel, itemHeight);
       } else {
         expect(scrollCount).toBe(1, '@scroll 2');
-        expect(virtualRepeat._first).toBe(988, 'repeat._first 2');
+        expect(virtualRepeat.$first).toBe(988, 'repeat._first 2');
         expect(virtualRepeat.items.length).toBe(12, 'items.length 1');
         expect(virtualRepeat.element.parentElement.scrollTop).toBe(100 * 995, 'scroller.scrollTop 1');
         await waitForNextFrame();
         expect(virtualRepeat.element.parentElement.scrollHeight).toBe(100 * 12, 'scroller.scrollHeight 2');
         expect(virtualRepeat.element.parentElement.scrollTop).toBe(100 * (12 - 500 / 100), 'scroller.scrollTop 2');
         expect(scrollCount).toBe(2, '@scroll 3');
-        expect(virtualRepeat._first).toBe(0, 'repeat._first 3');
+        expect(virtualRepeat.$first).toBe(0, 'repeat._first 3');
         validateScrolledState(virtualRepeat, viewModel, itemHeight);
       }
       virtualRepeat.element.parentElement.onscroll = null;
@@ -387,7 +387,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
         expect(virtualRepeat.element.parentElement.scrollHeight).toBe(100 * 13, '| vc >> scroller.scrollHeight 1');
         expect(virtualRepeat.element.parentElement.scrollTop).toBe(100 * (13 - 500 / 100), '| vc >> scroller.scrollTop 2');
 
-        expect(virtualRepeat._first).toBe(13 - (5 + 1) * 2, '| vc >> repeat._first 1');
+        expect(virtualRepeat.$first).toBe(13 - (5 + 1) * 2, '| vc >> repeat._first 1');
         validateScrolledState(virtualRepeat, viewModel, itemHeight);
       } else {
         expect(scrollCount).toBe(2, '@scroll 2');

--- a/test/vr-integration.instance-mutated.spec.ts
+++ b/test/vr-integration.instance-mutated.spec.ts
@@ -1,6 +1,6 @@
 import './setup';
 import { PLATFORM } from 'aurelia-pal';
-import { validateScrolledState, scrollToEnd, waitForNextFrame, waitForFrames } from './utilities';
+import { validateScrolledState, scrollToEnd, waitForNextFrame, waitForFrames, scrollRepeat } from './utilities';
 import { VirtualRepeat } from '../src/virtual-repeat';
 import { StageComponent, ComponentTester } from 'aurelia-testing';
 import { bootstrap } from 'aurelia-bootstrapper';
@@ -150,7 +150,8 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
   function runTestsCases(title: string, $view: string, extraResources: any[] = []): void {
     it([
       title,
-      '\thandles splice when scrolled to end'
+      '\thandles splice when scrolled to end',
+      ''
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
@@ -166,7 +167,8 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
 
     it([
       title,
-      '\thandles splice removing non-consecutive when scrolled to end'
+      '\thandles splice removing non-consecutive when scrolled to end',
+      ''
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({
         items: items,
@@ -197,7 +199,8 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       '\thandles splice non-consecutive when scrolled to end',
       '\t1000 items',
       '\t-- 12 max views',
-      '\t-- splice to 840 (every 10 increment, remove 3 add i, 80 times)'
+      '\t-- splice to 840 (every 10 increment, remove 3 add i, 80 times)',
+      ''
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
@@ -223,7 +226,8 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       '\thandles splice removing many',
       '\t1000 items',
       '\t-- 12 max views',
-      '\t-- splice to 24'
+      '\t-- splice to 24',
+      ''
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
@@ -242,7 +246,8 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
 
     it([
       title,
-      '\thandles splice removing more'
+      '\thandles splice removing more',
+      ''
     ].join('\n'), async () => {
       // number of items remaining exactly as viewslot capacity
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
@@ -259,7 +264,8 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
     // less items remaining than viewslot capacity
     it([
       title,
-      '\thandles splice removing even more'
+      '\thandles splice removing even more',
+      ''
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
@@ -274,7 +280,8 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
 
     it([
       title,
-      '\thandles splice removing non-consecutive'
+      '\thandles splice removing non-consecutive',
+      ''
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
@@ -289,7 +296,8 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
 
     it([
       title,
-      '\thandles splice non-consecutive'
+      '\thandles splice non-consecutive',
+      ''
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
@@ -307,7 +315,8 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       '\thandles splice removing many + add',
       '\t-- 1000 items',
       '\t-- 12 max views',
-      '\t-- spliced to 12'
+      '\t-- spliced to 12',
+      ''
     ].join('\n'), async () => {
       let scrollCount = 0;
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
@@ -316,8 +325,9 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       };
 
       expect(virtualRepeat._viewsLength).toBe(12, 'repeat._viewsLength');
-      await scrollToEnd(virtualRepeat, 50);
-      expect(scrollCount).toBe(2, '@scroll 1');
+      scrollRepeat(virtualRepeat, 'end');
+      await waitForNextFrame();
+      expect(scrollCount).toBe(1, '@scroll 1');
       expect(virtualRepeat.element.parentElement.scrollTop).toBe(100 * 995, 'anchor.parent.scrollTop 1');
       expect(virtualRepeat._first).toBe(988, 'repeat._first 1');
 
@@ -328,18 +338,18 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
         expect(virtualRepeat.element.parentElement.scrollHeight).toBe(100 * 12, '| vc >> scroller.scrollHeight 2');
         expect(virtualRepeat.element.parentElement.scrollTop).toBe(100 * (12 - 500 / 100), '| vc >> scroller.scrollTop 2');
         expect(scrollCount).toBeGreaterThanOrEqual(2, '| vc >> @scroll 3');
-        expect(virtualRepeat._first).toBe(6, '| vc >> repeat._first 2');
+        expect(virtualRepeat._first).toBe(0, '| vc >> repeat._first 2');
         validateScrolledState(virtualRepeat, viewModel, itemHeight);
       } else {
-        expect(scrollCount).toBe(2, '@scroll 2');
+        expect(scrollCount).toBe(1, '@scroll 2');
         expect(virtualRepeat._first).toBe(988, 'repeat._first 2');
         expect(virtualRepeat.items.length).toBe(12, 'items.length 1');
         expect(virtualRepeat.element.parentElement.scrollTop).toBe(100 * 995, 'scroller.scrollTop 1');
         await waitForNextFrame();
         expect(virtualRepeat.element.parentElement.scrollHeight).toBe(100 * 12, 'scroller.scrollHeight 2');
         expect(virtualRepeat.element.parentElement.scrollTop).toBe(100 * (12 - 500 / 100), 'scroller.scrollTop 2');
-        expect(scrollCount).toBe(3, '@scroll 3');
-        expect(virtualRepeat._first).toBe(6, 'repeat._first 3');
+        expect(scrollCount).toBe(2, '@scroll 3');
+        expect(virtualRepeat._first).toBe(0, 'repeat._first 3');
         validateScrolledState(virtualRepeat, viewModel, itemHeight);
       }
       virtualRepeat.element.parentElement.onscroll = null;
@@ -353,7 +363,8 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       '\thandles splice removing many + add',
       '\t1000 items',
       '\t-- 12 max views',
-      '\t-- spliced to 13'
+      '\t-- spliced to 13',
+      ''
     ].join('\n'), async () => {
       let scrollCount = 0;
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
@@ -376,7 +387,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
         expect(virtualRepeat.element.parentElement.scrollHeight).toBe(100 * 13, '| vc >> scroller.scrollHeight 1');
         expect(virtualRepeat.element.parentElement.scrollTop).toBe(100 * (13 - 500 / 100), '| vc >> scroller.scrollTop 2');
 
-        expect(virtualRepeat._first).toBe(7, '| vc >> repeat._first 1');
+        expect(virtualRepeat._first).toBe(13 - (5 + 1) * 2, '| vc >> repeat._first 1');
         validateScrolledState(virtualRepeat, viewModel, itemHeight);
       } else {
         expect(scrollCount).toBe(2, '@scroll 2');
@@ -392,7 +403,8 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
 
     it([
       title,
-      '\thandles splice remove remaining + add'
+      '\thandles splice remove remaining + add',
+      ''
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);

--- a/test/vr-integration.instance-mutated.spec.ts
+++ b/test/vr-integration.instance-mutated.spec.ts
@@ -231,16 +231,16 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
-      expect(virtualRepeat._viewsLength).toBe(12, 'virtualRepeat.viewsLength');
+      expect(virtualRepeat.minViewsRequired * 2).toBe(12, 'virtualRepeat.viewsLength');
       expect(virtualRepeat.element.parentElement.scrollTop).toEqual(100 * 995, 'scrollTop 1');
       // more items remaining than viewslot capacity
-      viewModel.items.splice(5, 1000 - virtualRepeat._viewsLength - 12);
+      viewModel.items.splice(5, 1000 - virtualRepeat.minViewsRequired * 2 - 12);
 
       await waitForNextFrame();
       expect(virtualRepeat.items.length).toEqual(24, 'virtualRepeat.items.length');
       expect(virtualRepeat.element.parentElement.scrollHeight).toEqual(100 * 24, 'scrollHeight 2');
       expect(virtualRepeat.element.parentElement.scrollTop).toEqual(100 * (24 - 5), 'scrollTop 2');
-      expect(virtualRepeat._first).toBe(1000 - (1000 - virtualRepeat._viewsLength), 'virtualRepeat._first 1');
+      expect(virtualRepeat._first).toBe(1000 - (1000 - virtualRepeat.minViewsRequired * 2), 'virtualRepeat._first 1');
       validateScrolledState(virtualRepeat, viewModel, itemHeight);
     });
 
@@ -253,7 +253,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
 
-      viewModel.items.splice(5, 1000 - virtualRepeat._viewsLength);
+      viewModel.items.splice(5, 1000 - virtualRepeat.minViewsRequired * 2);
 
       await waitForNextFrame();
 
@@ -270,7 +270,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
 
-      viewModel.items.splice(5, 1000 - virtualRepeat._viewsLength + 10);
+      viewModel.items.splice(5, 1000 - virtualRepeat.minViewsRequired * 2 + 10);
 
       await waitForNextFrame();
 
@@ -324,7 +324,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
         scrollCount++;
       };
 
-      expect(virtualRepeat._viewsLength).toBe(12, 'repeat._viewsLength');
+      expect(virtualRepeat.minViewsRequired * 2).toBe(12, 'repeat._viewsLength');
       scrollRepeat(virtualRepeat, 'end');
       await waitForNextFrame();
       expect(scrollCount).toBe(1, '@scroll 1');
@@ -372,7 +372,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
         scrollCount++;
       };
 
-      expect(virtualRepeat._viewsLength).toBe(12, 'repeat._viewsLength');
+      expect(virtualRepeat.minViewsRequired * 2).toBe(12, 'repeat._viewsLength');
       await scrollToEnd(virtualRepeat);
       expect(scrollCount).toBe(2, '@scroll 1');
       expect(virtualRepeat.element.parentElement.scrollTop).toBe(100 * 995);

--- a/test/vr-integration.resizing.spec.ts
+++ b/test/vr-integration.resizing.spec.ts
@@ -356,8 +356,8 @@ describe('vr-integration.resizing.spec.ts', () => {
 
   function assertElementsInView(repeat: VirtualRepeat, ctHeight: number, itemHeight: number, extraTitle: string = ''): void {
     const itemsCount = Array.isArray(repeat.items) ? repeat.items.length : 0;
-    const elementsInView = itemsCount === 0 ? 0 : repeat.elementsInView;
-    const viewsLength = itemsCount === 0 ? 0 : repeat._viewsLength;
+    const elementsInView = itemsCount === 0 ? 0 : repeat.minViewsRequired;
+    const viewsLength = itemsCount === 0 ? 0 : repeat.minViewsRequired * 2;
     const expectedElementsInView = itemsCount === 0
       ? 0
       : itemHeight === 0

--- a/test/vr-integration.scrolling.spec.ts
+++ b/test/vr-integration.scrolling.spec.ts
@@ -4,13 +4,16 @@ import { ComponentTester, StageComponent } from 'aurelia-testing';
 import { VirtualRepeat } from '../src/virtual-repeat';
 import { ITestAppInterface } from './interfaces';
 import './setup';
-import { AsyncQueue, createAssertionQueue, ensureScrolled, validateState, createScrollEvent, waitForNextFrame } from './utilities';
+import { AsyncQueue, createAssertionQueue, waitForNextFrame } from './utilities';
+import { CloneArrayValueConverter, IdentityValueConverter } from './value-converters';
+import { eachCartesianJoin, eachCartesianJoinAsync } from './lib';
+import { calcMinViewsRequired as calcMinViewsRequired } from '../src/utilities';
 
 PLATFORM.moduleName('src/virtual-repeat');
 PLATFORM.moduleName('test/noop-value-converter');
 PLATFORM.moduleName('src/infinite-scroll-next');
 
-describe('VirtualRepeat Integration - Scrolling', () => {
+describe('vr-integration.scrolling.spec.ts', () => {
   const itemHeight = 100;
   const queue: AsyncQueue = createAssertionQueue();
   let component: ComponentTester<VirtualRepeat>;
@@ -43,95 +46,95 @@ describe('VirtualRepeat Integration - Scrolling', () => {
   // Note that any test related to table, ignore border spacing as it's not easy to calculate in test environment
   // todo: have tests for margin / border spacing
 
-  describe('<tr virtual-repeat.for>', () => {
+  // describe('<tr virtual-repeat.for>', () => {
 
-    beforeEach(() => {
-      view =
-      `<div id="scrollCtEl" style="height: 500px; overflow-y: auto">
-        <table style="border-spacing: 0">
-          <tr style="height: 30px">
-            <th>#</th>
-            <th>Name</th>
-          <tr>
-          <tr virtual-repeat.for="item of items" style="height: 50px;">
-            <td>\${$index}</td>
-            <td>\${item}</td>
-          </tr>
-        </table>
-      </div>`;
-    });
+  //   beforeEach(() => {
+  //     view =
+  //     `<div style="height: 500px; overflow-y: auto">
+  //       <table style="border-spacing: 0">
+  //         <tr style="height: 30px">
+  //           <th>#</th>
+  //           <th>Name</th>
+  //         <tr>
+  //         <tr virtual-repeat.for="item of items" style="height: 50px;">
+  //           <td>\${$index}</td>
+  //           <td>\${item}</td>
+  //         </tr>
+  //       </table>
+  //     </div>`;
+  //   });
 
-    it([
-      '100 items',
-      '\t[header row] <-- h:30',
-      '\t[body rows] <-- h:50 each',
-      '\t-- scrollTop from 0 to 79 should not affect first row'
-    ].join('\n'), async () => {
-      const { viewModel, virtualRepeat } = await bootstrapComponent({ items: createItems(100) });
-      const scrollCtEl = document.querySelector('#scrollCtEl');
-      expect(scrollCtEl.scrollHeight).toEqual(100 * 50 + 30, 'scrollCtEl.scrollHeight');
-      for (let i = 0; 79 > i; ++i) {
-        scrollCtEl.scrollTop = i;
-        await waitForNextFrame();
-        expect(virtualRepeat.view(0).bindingContext.item).toEqual('item0');
-        // todo: more validation of scrolled state here
-      }
-      for (let i = 80; 80 + 49 > i; ++i) {
-        scrollCtEl.scrollTop = i;
-        await waitForNextFrame();
-        expect(virtualRepeat.view(0).bindingContext.item).toEqual('item1');
-        // todo: more validation of scrolled state here
-      }
-    });
+  //   it([
+  //     '100 items',
+  //     '\t[header row] <-- h:30',
+  //     '\t[body rows] <-- h:50 each',
+  //     '\t-- scrollTop from 0 to 79 should not affect first row'
+  //   ].join('\n'), async () => {
+  //     const { viewModel, virtualRepeat } = await bootstrapComponent({ items: createItems(100) });
+  //     const scrollCtEl = virtualRepeat.getScroller();
+  //     expect(scrollCtEl.scrollHeight).toEqual(100 * 50 + 30, 'scrollCtEl.scrollHeight');
+  //     for (let i = 0; 79 > i; ++i) {
+  //       scrollCtEl.scrollTop = i;
+  //       await waitForNextFrame();
+  //       expect(virtualRepeat.view(0).bindingContext.item).toEqual('item0');
+  //       // todo: more validation of scrolled state here
+  //     }
+  //     for (let i = 80; 80 + 49 > i; ++i) {
+  //       scrollCtEl.scrollTop = i;
+  //       await waitForNextFrame();
+  //       expect(virtualRepeat.view(0).bindingContext.item).toEqual('item1');
+  //       // todo: more validation of scrolled state here
+  //     }
+  //   });
 
-  });
+  // });
 
-  describe('<tbody virtual-repeat.for>', () => {
+  // describe('<tbody virtual-repeat.for>', () => {
 
-    beforeEach(() => {
-      view =
-      `<div id="scrollCtEl" style="height: 500px; overflow-y: auto">
-        <table style="border-spacing: 0">
-          <thead>
-            <tr style="height: 30px">
-              <th>#</th>
-              <th>Name</th>
-            <tr>
-          </thead>
-          <tbody virtual-repeat.for="item of items">
-            <tr style="height: 50px;">
-              <td>\${$index}</td>
-              <td>\${item}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>`;
-    });
+  //   beforeEach(() => {
+  //     view =
+  //     `<div style="height: 500px; overflow-y: auto">
+  //       <table style="border-spacing: 0">
+  //         <thead>
+  //           <tr style="height: 30px">
+  //             <th>#</th>
+  //             <th>Name</th>
+  //           <tr>
+  //         </thead>
+  //         <tbody virtual-repeat.for="item of items">
+  //           <tr style="height: 50px;">
+  //             <td>\${$index}</td>
+  //             <td>\${item}</td>
+  //           </tr>
+  //         </tbody>
+  //       </table>
+  //     </div>`;
+  //   });
 
-    it([
-      '100 items',
-      '\t[theader row] <-- h:30',
-      '\t[tbody rows] <-- h:50 each',
-      '\t-- scrollTop from 0 to 79 should not affect first row'
-    ].join('\n'), async () => {
-      const { viewModel, virtualRepeat } = await bootstrapComponent({ items: createItems(100) });
-      const scrollCtEl = document.querySelector('#scrollCtEl');
-      expect(scrollCtEl.scrollHeight).toEqual(100 * 50 + 30, 'scrollCtEl.scrollHeight');
-      for (let i = 0; 79 > i; ++i) {
-        scrollCtEl.scrollTop = i;
-        await waitForNextFrame();
-        expect(virtualRepeat.view(0).bindingContext.item).toEqual('item0');
-        // todo: more validation of scrolled state here
-      }
-      for (let i = 80; 80 + 49 > i; ++i) {
-        scrollCtEl.scrollTop = i;
-        await waitForNextFrame();
-        expect(virtualRepeat.view(0).bindingContext.item).toEqual('item1');
-        // todo: more validation of scrolled state here
-      }
-    });
+  //   it([
+  //     '100 items',
+  //     '\t[theader row] <-- h:30',
+  //     '\t[tbody rows] <-- h:50 each',
+  //     '\t-- scrollTop from 0 to 79 should not affect first row'
+  //   ].join('\n'), async () => {
+  //     const { viewModel, virtualRepeat } = await bootstrapComponent({ items: createItems(100) });
+  //     const scrollCtEl = document.querySelector('#scrollCtEl');
+  //     expect(scrollCtEl.scrollHeight).toEqual(100 * 50 + 30, 'scrollCtEl.scrollHeight');
+  //     for (let i = 0; 79 > i; ++i) {
+  //       scrollCtEl.scrollTop = i;
+  //       await waitForNextFrame();
+  //       expect(virtualRepeat.view(0).bindingContext.item).toEqual('item0');
+  //       // todo: more validation of scrolled state here
+  //     }
+  //     for (let i = 80; 80 + 49 > i; ++i) {
+  //       scrollCtEl.scrollTop = i;
+  //       await waitForNextFrame();
+  //       expect(virtualRepeat.view(0).bindingContext.item).toEqual('item1');
+  //       // todo: more validation of scrolled state here
+  //     }
+  //   });
 
-  });
+  // });
 
   describe('multiple repeats', () => {
 
@@ -166,7 +169,7 @@ describe('VirtualRepeat Integration - Scrolling', () => {
       '\t[body rows] <-- h:50 each',
       '\t-- scrollTop from 0 to 79 should not affect first row'
     ].join('\n'), async () => {
-      const { viewModel, virtualRepeat } = await bootstrapComponent({ items: createItems(100) });
+      const { viewModel, virtualRepeat } = await bootstrapComponent({ items: createItems(100) }, view);
       const scrollCtEl = document.querySelector('#scrollCtEl');
       expect(scrollCtEl.scrollHeight).toEqual(
         /* 2 repeats */200
@@ -175,13 +178,13 @@ describe('VirtualRepeat Integration - Scrolling', () => {
         + /* height of separator */100,
         'scrollCtEl.scrollHeight'
       );
-      for (let i = 0; 79 > i; ++i) {
+      for (let i = 0; 79 > i; i += 7) {
         scrollCtEl.scrollTop = i;
         await waitForNextFrame();
         expect(virtualRepeat.view(0).bindingContext.item).toEqual('item0');
         // todo: more validation of scrolled state here
       }
-      for (let i = 80; 80 + 49 > i; ++i) {
+      for (let i = 80; 80 + 49 > i; i += 7) {
         scrollCtEl.scrollTop = i;
         await waitForNextFrame();
         expect(virtualRepeat.view(0).bindingContext.item).toEqual('item1');
@@ -190,7 +193,7 @@ describe('VirtualRepeat Integration - Scrolling', () => {
       const secondRepeatStart = 100 * 50 + 30 + 100;
       const secondRepeat = component['rootView'].controllers[1].viewModel;
       expect(secondRepeat).toBeDefined();
-      for (let i = 0; 50 > i; ++i) {
+      for (let i = 0; 50 > i; i += 7) {
         scrollCtEl.scrollTop = secondRepeatStart + i;
         await waitForNextFrame();
         expect(virtualRepeat._topBufferHeight).toEqual(100 * 50 - (500 / 50 + 1) * 2 * 50, 'height:repeat1.topBuffer');
@@ -201,11 +204,228 @@ describe('VirtualRepeat Integration - Scrolling', () => {
     });
   });
 
+  const repeatScrollNextCombos: IRepeatScrollNextCombo[] = [
+    ['', 'infinite-scroll-next="getNextPage"'],
+    ['', 'infinite-scroll-next.call="getNextPage($scrollContext)"'],
+    [' & toView', 'infinite-scroll-next="getNextPage"'],
+    [' & twoWay', 'infinite-scroll-next="getNextPage"'],
+    [' & twoWay', 'infinite-scroll-next.call="getNextPage($scrollContext)"'],
+    [' | cloneArray', 'infinite-scroll-next="getNextPage"', [CloneArrayValueConverter]],
+    [' | cloneArray', 'infinite-scroll-next.call="getNextPage($scrollContext)"', [CloneArrayValueConverter]],
+    [' | identity | cloneArray & toView', 'infinite-scroll-next="getNextPage"', [IdentityValueConverter, CloneArrayValueConverter]],
+    [' | identity | cloneArray & toView', 'infinite-scroll-next.call="getNextPage($scrollContext)"', [IdentityValueConverter, CloneArrayValueConverter]],
+    [' | cloneArray & toView', 'infinite-scroll-next="getNextPage"', [CloneArrayValueConverter]]
 
-  async function bootstrapComponent<T>($viewModel?: ITestAppInterface<T>, $view?: string) {
+    // cloneArray and two way creates infinite loop
+    // [' | cloneArray & twoWay', 'infinite-scroll-next="getNextPage"', [CloneArrayValueConverter]]
+  ];
+
+  const scrollingTestGroups: IScrollingTestCaseGroup[] = [
+    {
+      topBufferOffset: 30,
+      itemHeight: 50,
+      scrollerHeight: 500,
+      title: (itemHeight, scrollerHeight, topBufferOffset, repeatAttr: string) =>
+        [
+          `div[scroller h:${scrollerHeight}] > table > tr[repeat${repeatAttr}]`,
+          '-- 100 items',
+          `-- [theader row] <-- h:${topBufferOffset}`,
+          `-- [tr rows] <-- h:${itemHeight} each`,
+          ''
+        ].join('\n\t'),
+      createView: (itemHeight, scrollerHeight, topBufferOffset, repeatAttr) =>
+        `<div style="height: ${scrollerHeight}px; overflow-y: auto">
+          <table style="border-spacing: 0">
+            <thead>
+              <tr style="height: ${topBufferOffset}px">
+                <th>#</th>
+                <th>Name</th>
+              <tr>
+            </thead>
+            <tr virtual-repeat.for="item of items ${repeatAttr}" style="height: ${itemHeight}px;">
+              <td>\${$index}</td>
+              <td>\${item}</td>
+            </tr>
+          </table>
+        </div>`
+    },
+    {
+      topBufferOffset: 30,
+      itemHeight: 50,
+      scrollerHeight: 500,
+      title: (itemHeight, scrollerHeight, topBufferOffset, repeatAttr: string) =>
+        [
+          `div[scroller h:${scrollerHeight}] > table > tbody[repeat${repeatAttr}]`,
+          '-- 100 items',
+          `-- [theader row] <-- h:${topBufferOffset}`,
+          `-- [tbody rows] <-- h:${itemHeight} each`,
+          ''
+        ].join('\n\t'),
+      createView: (itemHeight, scrollerHeight, topBufferOffset, repeatAttr) =>
+        `<div style="height: ${scrollerHeight}px; overflow-y: auto">
+          <table style="border-spacing: 0">
+            <thead>
+              <tr style="height: ${topBufferOffset}px">
+                <th>#</th>
+                <th>Name</th>
+              <tr>
+            </thead>
+            <tbody virtual-repeat.for="item of items ${repeatAttr}">
+              <tr style="height: ${itemHeight}px;">
+                <td>\${$index}</td>
+                <td>\${item}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>`
+    },
+    {
+      topBufferOffset: 0,
+      itemHeight: 50,
+      scrollerHeight: 500,
+      title: (itemHeight, scrollerHeight, topBufferOffset, repeatAttr: string) =>
+        [
+          `div[scroller h:${scrollerHeight}] > ol > li[repeat${repeatAttr}]`,
+          '-- 100 items',
+          `-- [li rows] <-- h:${itemHeight} each`,
+          ''
+        ].join('\n\t'),
+      createView: (itemHeight, scrollerHeight, topBufferOffset, repeatAttr) =>
+        `<div style="height: ${scrollerHeight}px; overflow-y: auto">
+          <ol style="list-style: none; margin: 0;">
+            <li virtual-repeat.for="item of items ${repeatAttr}" style="height: ${itemHeight}px;">
+              \${$index}
+            </li>
+          </ol>
+        </div>`
+    },
+    {
+      topBufferOffset: 0,
+      itemHeight: 50,
+      scrollerHeight: 500,
+      title: (itemHeight, scrollerHeight, topBufferOffset, repeatAttr: string) =>
+        [
+          `ol[scroller h:${scrollerHeight}] > li[repeat${repeatAttr}]`,
+          '-- 100 items',
+          `-- [li rows] <-- h:${itemHeight} each`,
+          ''
+        ].join('\n\t'),
+      createView: (itemHeight, scrollerHeight, topBufferOffset, repeatAttr) =>
+        `<ol style="height: ${scrollerHeight}px; overflow-y: auto; list-style: none; margin: 0;">
+          <li virtual-repeat.for="item of items ${repeatAttr}" style="height: ${itemHeight}px;">
+            \${$index}
+          </li>
+        </ol>`
+    }
+  ];
+
+  eachCartesianJoin(
+    [repeatScrollNextCombos, scrollingTestGroups],
+    (testAttributesCombo, testGroup) => {
+      const [repeatAttr, scrollNextAttr, resources] = testAttributesCombo;
+      const { title, itemHeight, scrollerHeight, topBufferOffset, createView, extraAssert } = testGroup;
+      runTestGroup(
+        title(itemHeight, scrollerHeight, topBufferOffset, repeatAttr),
+        createView(itemHeight, scrollerHeight, topBufferOffset, repeatAttr),
+        { itemHeight, scrollerHeight, topBufferOffset },
+        extraAssert
+      );
+    }
+  );
+
+  function runTestGroup(
+    title: string,
+    $view: string,
+    {
+      itemHeight,
+      scrollerHeight,
+      topBufferOffset
+    }: {
+      itemHeight: number;
+      scrollerHeight: number;
+      topBufferOffset: number;
+    },
+    extraAssert: (repeat, component) => void,
+    extraResources?: any[]
+  ): void {
+    describe(title, () => {
+      it([
+        '100 items',
+        `-- scrollTop from 0 to ${itemHeight - 1} should not affect first row`
+      ].join('\n\t'), async () => {
+        const ITEM_COUNT = 100;
+        const { viewModel, virtualRepeat } = await bootstrapComponent(
+          { items: createItems(ITEM_COUNT) },
+          $view,
+          [CloneArrayValueConverter, IdentityValueConverter]
+        );
+        const scrollCtEl = virtualRepeat.getScroller();
+        expect(scrollCtEl.scrollHeight).toEqual(ITEM_COUNT * itemHeight + topBufferOffset, 'scrollCtEl.scrollHeight');
+        for (let i = 0; itemHeight > i; i += Math.floor(itemHeight / 9)) {
+          scrollCtEl.scrollTop = i;
+          await waitForNextFrame();
+          expect(virtualRepeat.view(0).bindingContext.item).toEqual('item0');
+          // todo: more validation of scrolled state here
+        }
+        for (let i = itemHeight + topBufferOffset; itemHeight + topBufferOffset + (itemHeight - 1) > i; i += Math.floor(itemHeight / 9)) {
+          scrollCtEl.scrollTop = i;
+          await waitForNextFrame();
+          expect(virtualRepeat.view(0).bindingContext.item).toEqual('item1');
+          // todo: more validation of scrolled state here
+        }
+      });
+
+      it([
+        `100 items`,
+        `-- scroll to bottom`,
+        `-- scroll from bottom to index ${100 - calcMinViewsRequired(scrollerHeight, itemHeight)} should not affect first row`
+      ].join('\n\t'), async () => {
+        const ITEM_COUNT = 100;
+        const { viewModel, virtualRepeat } = await bootstrapComponent(
+          { items: createItems(ITEM_COUNT) },
+          $view,
+          [CloneArrayValueConverter, IdentityValueConverter]
+        );
+        const scroller_el = virtualRepeat.getScroller();
+        expect(scroller_el.scrollHeight).toEqual(ITEM_COUNT * itemHeight + topBufferOffset, 'scrollCtEl.scrollHeight');
+        scroller_el.scrollTop = scroller_el.scrollHeight;
+        await waitForNextFrame();
+        const minViewsRequired = calcMinViewsRequired(scrollerHeight, itemHeight);
+        const maxViewsRequired = minViewsRequired * 2;
+        let expected_first_index = 100 - maxViewsRequired;
+        expect(virtualRepeat._first).toBe(expected_first_index, '@scroll bottom -> repeat._first 1');
+
+        const maxScrollTop = scroller_el.scrollTop;
+        // only minViewsRequired > i because by default
+        // it's already scrolled half way equal to minViewsRequired as scrollTop max = scrollHeight - minViewsRequired * itemHeight
+        for (let i = 0; minViewsRequired >= i; ++i) {
+          scroller_el.scrollTop = maxScrollTop - i * itemHeight;
+          await waitForNextFrame();
+          expect(virtualRepeat._first).toBe(expected_first_index, '@scroll ⬆ -> repeat._first 2:' + i);
+        }
+      });
+    });
+  }
+
+  type IRepeatScrollNextCombo = [
+    /*repeat extra expression*/string,
+    /*infinite-scroll-next attr*/string,
+    /*extraResources*/ any[]?
+  ];
+
+  interface IScrollingTestCaseGroup {
+    topBufferOffset: number;
+    itemHeight: number;
+    scrollerHeight: number;
+    title: (itemHeight: number, scrollerHeight: number, topBufferOffset: number, repeatAttr: string) => string;
+    createView: (itemHeight: number, scrollerHeight: number, topBufferOffset: number, repeatAttr: string) => string;
+    extraAssert?: (repeat: VirtualRepeat, component: ComponentTester<VirtualRepeat>) => void;
+  }
+
+  async function bootstrapComponent<T>($viewModel: ITestAppInterface<T>, $view: string, extraResources: any[] = []) {
     component = StageComponent
-      .withResources(resources)
-      .inView($view || view)
+      .withResources(Array.from(new Set([...resources, ...extraResources])))
+      .inView($view)
       .boundTo($viewModel);
     await component.create(bootstrap);
     return { virtualRepeat: component.viewModel, viewModel: $viewModel, component: component };

--- a/test/vr-integration.scrolling.spec.ts
+++ b/test/vr-integration.scrolling.spec.ts
@@ -196,8 +196,8 @@ describe('vr-integration.scrolling.spec.ts', () => {
       for (let i = 0; 50 > i; i += 7) {
         scrollCtEl.scrollTop = secondRepeatStart + i;
         await waitForNextFrame();
-        expect(virtualRepeat._topBufferHeight).toEqual(100 * 50 - (500 / 50 + 1) * 2 * 50, 'height:repeat1.topBuffer');
-        expect(virtualRepeat._bottomBufferHeight).toEqual(0, 'height:repeat1.botBuffer');
+        expect(virtualRepeat.topBufferHeight).toEqual(100 * 50 - (500 / 50 + 1) * 2 * 50, 'height:repeat1.topBuffer');
+        expect(virtualRepeat.bottomBufferHeight).toEqual(0, 'height:repeat1.botBuffer');
         expect(secondRepeat.view(0).bindingContext.item).toEqual('item0');
         // todo: more validation of scrolled state here
       }
@@ -393,7 +393,7 @@ describe('vr-integration.scrolling.spec.ts', () => {
         const minViewsRequired = calcMinViewsRequired(scrollerHeight, itemHeight);
         const maxViewsRequired = minViewsRequired * 2;
         let expected_first_index = 100 - maxViewsRequired;
-        expect(virtualRepeat._first).toBe(expected_first_index, '@scroll bottom -> repeat._first 1');
+        expect(virtualRepeat.$first).toBe(expected_first_index, '@scroll bottom -> repeat._first 1');
 
         const maxScrollTop = scroller_el.scrollTop;
         // only minViewsRequired > i because by default
@@ -401,7 +401,7 @@ describe('vr-integration.scrolling.spec.ts', () => {
         for (let i = 0; minViewsRequired >= i; ++i) {
           scroller_el.scrollTop = maxScrollTop - i * itemHeight;
           await waitForNextFrame();
-          expect(virtualRepeat._first).toBe(expected_first_index, '@scroll ⬆ -> repeat._first 2:' + i);
+          expect(virtualRepeat.$first).toBe(expected_first_index, '@scroll ⬆ -> repeat._first 2:' + i);
         }
       });
     });


### PR DESCRIPTION
* Atm, repeat scroll handling is done via complex tracking with multiple private states writes and read. 
 Simplify it to use only 1 state: the scroll position, and pass around more information in function parameter to have cleaner methods. This should make it friendly for contributors. The new scroll handling is based on 2 ranges intersection comparison: between before-scroll (range-1) and after-scroll (range-2).

* remove all collection length access from virtual repeat, as a step 1 towards support other types of collection: number, map, set. Reviewer can have a look at interface at `VirtualRepeatStrategy` to quickly grasp the idea.

* Adjust tests, as the timing has been adjusted.

* invoke infinite scroll next earlier - 5 views (items count) before reaching either bottom or top.

New examples:

* multiple list on document, with better perf since with new scroll handling behavior, some unnecessary work is eliminated https://dist-oxwuvydspa.now.sh/#/contrived-examples/multiple-lists-document

* grid with sticky header / index column, thanks to @jorgenskogas https://dist-oxwuvydspa.now.sh/#/non-issues/scroller-not-first-parent-div

* infinite-scroll-previous with scrolling behavior similar to normal repeat: adjust scroll position to keep the current top visible item in the viewport https://dist-nfkwghxnfg.now.sh/#/issue-117 Note that repeat expression with value converter will not have the behavior.

closes #117
closes #95 