### PR TITLE
Removing event listener also in document object when detaching

### DIFF
--- a/src/virtual-repeat.js
+++ b/src/virtual-repeat.js
@@ -124,6 +124,7 @@ export class VirtualRepeat extends AbstractRepeater {
 
   detached(): void {
     this.scrollContainer.removeEventListener('scroll', this.scrollListener);
+    document.removeEventListener('scroll', this.scrollListener);
     this._resetCalculation();
     this._isAttached = false;
     this.templateStrategy.removeBufferElements(this.element, this.topBuffer, this.bottomBuffer);


### PR DESCRIPTION
When detaching an object with _ui-virtualization_ applied, there is a need to remove scroll listener also from the _document_ object. Otherwise in the _document_ object there are as many scroll listeners as a page with _ui-virutalization_ element was opened.