### PR TITLE
Fix: get more not getting call when the scroll information cannot be determined from view indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ There are three parameters that are passed to the function (`getMore(topIndex, i
     </div>
   </template>
   ```
-  4. Similar to (3), virtualization requires appropriate removing and inserting visible items, corresponding lifecycle of items view will also be triggered while inserting (`bind`, `attached`) or removing (`unbind`, `detached`)
+  4. Similar to (3), virtualization requires appropriate removing and inserting visible items, so not all views will have their lifecycle invoked repeatedly. Rather, their binding contexts will be updated accordingly when the virtual repeat reuses the view and view model. To work around this, you can have your components work in a reactive way, which is natural in an Aurelia application. An example is to handle changes in change handler callback.
 
 ## [Demo](https://aurelia-ui-virtualization.now.sh/)
 

--- a/sample/demo-app/index.ejs
+++ b/sample/demo-app/index.ejs
@@ -9,7 +9,7 @@
     <link rel='stylesheet' href='static/css/bootstrap.min.css'>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" crossorigin="anonymous">
     <link rel="stylesheet" href="static/style.css">
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6,es7&flags=gated" crossorigin="anonymous"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=Promise&flags=gated" crossorigin="anonymous"></script>
     <script src="https://cdn.rawgit.com/Marak/faker.js/master/build/build/faker.min.js" crossorigin="anonymous"></script>
   </head>
   <body>

--- a/sample/demo-app/src/main.ts
+++ b/sample/demo-app/src/main.ts
@@ -1,3 +1,4 @@
+import 'aurelia-polyfills';
 import { Aurelia, PLATFORM } from 'aurelia-framework';
 
 declare const PRODUCTION: boolean;
@@ -11,13 +12,13 @@ export async function configure(aurelia: Aurelia) {
         class {
           static $resource = {
             type: 'valueConverter',
-            name: 'identity'
+            name: 'identity',
           };
 
           toView(val: any) {
             return val;
           }
-        }
+        },
       ] as any[]);
 
     if (!PRODUCTION) {

--- a/src/array-virtual-repeat-strategy.ts
+++ b/src/array-virtual-repeat-strategy.ts
@@ -29,6 +29,10 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy implements I
     return repeat.addView(overrideContext.bindingContext, overrideContext);
   }
 
+  count(items: any[]): number {
+    return items.length;
+  }
+
   initCalculation(repeat: IVirtualRepeater, items: any[]): VirtualizationCalculation {
     const itemCount = items.length;
     // when there is no item, bails immediately

--- a/src/array-virtual-repeat-strategy.ts
+++ b/src/array-virtual-repeat-strategy.ts
@@ -125,7 +125,7 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy implements I
     return lastIndex === -1
       ? true
       : itemCount > 0
-        ? lastIndex > (itemCount - repeat.edgeDistance)
+        ? lastIndex > (itemCount - 1 - repeat.edgeDistance)
         : false;
   }
 
@@ -526,7 +526,7 @@ export class ArrayVirtualRepeatStrategy extends ArrayRepeatStrategy implements I
     const real_scroll_top = Math$max(0, scroller_scroll_top === 0
       ? 0
       : (scroller_scroll_top - top_buffer_distance));
-      let first_index_after_scroll_adjustment = real_scroll_top === 0
+    let first_index_after_scroll_adjustment = real_scroll_top === 0
       ? 0
       : Math$floor(real_scroll_top / itemHeight);
 

--- a/src/aurelia-ui-virtualization.ts
+++ b/src/aurelia-ui-virtualization.ts
@@ -15,5 +15,6 @@ export {
 
 export {
   IScrollNextScrollContext,
-  VirtualizationEvents
+  VirtualizationEvents,
+  RepeatableValue
 } from './interfaces';

--- a/src/aurelia-ui-virtualization.ts
+++ b/src/aurelia-ui-virtualization.ts
@@ -10,11 +10,11 @@ export function configure(config: { globalResources(...args: any[]): any; }) {
 
 export {
   VirtualRepeat,
-  InfiniteScrollNext
+  InfiniteScrollNext,
 };
 
 export {
   IScrollNextScrollContext,
   VirtualizationEvents,
-  RepeatableValue
+  RepeatableValue,
 } from './interfaces';

--- a/src/infinite-scroll-next.ts
+++ b/src/infinite-scroll-next.ts
@@ -5,7 +5,7 @@ export class InfiniteScrollNext {
   static $resource() {
     return {
       type: 'attribute',
-      name: 'infinite-scroll-next'
+      name: 'infinite-scroll-next',
     };
   }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -367,11 +367,15 @@ export const VirtualizationEvents = Object.assign(Object.create(null), {
 };
 
 export const enum ScrollingState {
-  none              = 0,
-  isScrollingDown   = 0b0_00001,
-  isScrollingUp     = 0b0_00010,
-  isNearTop         = 0b0_00100,
-  isNearBottom      = 0b0_01000
+  none                          = 0,
+  isScrollingDown               = 0b0_00001,
+  isScrollingUp                 = 0b0_00010,
+  isNearTop                     = 0b0_00100,
+  isNearBottom                  = 0b0_01000,
+  /**@internal */
+  isScrollingDownAndNearBottom  = isScrollingDown | isNearBottom,
+  /**@internal */
+  isScrollingUpAndNearTop       = isScrollingUp | isNearTop
 }
 
 // export const enum IVirtualRepeatState {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -352,7 +352,7 @@ export const enum VirtualizationCalculation {
   none              = 0b0_00000,
   reset             = 0b0_00001,
   has_sizing        = 0b0_00010,
-  observe_scroller  = 0b0_00100
+  observe_scroller  = 0b0_00100,
 }
 
 export interface IElement {
@@ -367,7 +367,7 @@ export interface IElement {
  */
 export const VirtualizationEvents = Object.assign(Object.create(null), {
   scrollerSizeChange: 'virtual-repeat-scroller-size-changed' as 'virtual-repeat-scroller-size-changed',
-  itemSizeChange: 'virtual-repeat-item-size-changed' as 'virtual-repeat-item-size-changed'
+  itemSizeChange: 'virtual-repeat-item-size-changed' as 'virtual-repeat-item-size-changed',
 }) as {
   scrollerSizeChange: 'virtual-repeat-scroller-size-changed';
   itemSizeChange: 'virtual-repeat-item-size-changed';
@@ -382,7 +382,7 @@ export const enum ScrollingState {
   /**@internal */
   isScrollingDownAndNearBottom  = isScrollingDown | isNearBottom,
   /**@internal */
-  isScrollingUpAndNearTop       = isScrollingUp | isNearTop
+  isScrollingUpAndNearTop       = isScrollingUp | isNearTop,
 }
 
 // export const enum IVirtualRepeatState {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -190,18 +190,25 @@ export interface IVirtualRepeater extends AbstractRepeater {
   updateBufferElements(skipUpdate?: boolean): void;
 }
 
-export interface IVirtualRepeatStrategy {
+export type RepeatableValue = number | any[] | Map<any, any> | Set<any>;
+
+export interface IVirtualRepeatStrategy<T extends RepeatableValue = RepeatableValue> {
   /**
    * create first item to calculate the heights
    */
   createFirstRow(repeat: IVirtualRepeater): IView;
 
   /**
+   * Count the number of the items in the repeatable value `items`
+   */
+  count(items: T): number;
+
+  /**
    * Calculate required variables for a virtual repeat instance to operate properly
    *
    * @returns `false` to notify that calculation hasn't been finished
    */
-  initCalculation(repeat: IVirtualRepeater, items: number | any[] | Map<any, any> | Set<any>): VirtualizationCalculation;
+  initCalculation(repeat: IVirtualRepeater, items: T): VirtualizationCalculation;
 
   /**
    * Handle special initialization if any, depends on different strategy
@@ -233,7 +240,7 @@ export interface IVirtualRepeatStrategy {
   /**
    * Get the observer based on collection type of `items`
    */
-  getCollectionObserver(observerLocator: ObserverLocator, items: any[] | Map<any, any> | Set<any>): InternalCollectionObserver;
+  getCollectionObserver(observerLocator: ObserverLocator, items: T): InternalCollectionObserver;
 
   /**
    * @override
@@ -242,16 +249,16 @@ export interface IVirtualRepeatStrategy {
    * @param items The new array instance.
    * @param firstIndex The index of first active view
    */
-  instanceChanged(repeat: IVirtualRepeater, items: any[] | Map<any, any> | Set<any>, firstIndex?: number): void;
+  instanceChanged(repeat: IVirtualRepeater, items: T, firstIndex?: number): void;
 
   /**
    * @override
    * Handle the repeat's collection instance mutating.
    * @param repeat The virtual repeat instance.
-   * @param array The modified array.
+   * @param items The modified array.
    * @param splices Records of array changes.
    */
-  instanceMutated(repeat: IVirtualRepeater, array: any[], splices: ICollectionObserverSplice[]): void;
+  instanceMutated(repeat: IVirtualRepeater, items: any[], splices: ICollectionObserverSplice[]): void;
 
   /**
    * Unlike normal repeat, virtualization repeat employs "padding" elements. Those elements

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -258,7 +258,7 @@ export interface IVirtualRepeatStrategy<T extends RepeatableValue = RepeatableVa
    * @param items The modified array.
    * @param splices Records of array changes.
    */
-  instanceMutated(repeat: IVirtualRepeater, items: any[], splices: ICollectionObserverSplice[]): void;
+  instanceMutated(repeat: IVirtualRepeater, items: RepeatableValue, splices: ICollectionObserverSplice[]): void;
 
   /**
    * Unlike normal repeat, virtualization repeat employs "padding" elements. Those elements

--- a/src/null-virtual-repeat-strategy.ts
+++ b/src/null-virtual-repeat-strategy.ts
@@ -4,6 +4,16 @@ import { IVirtualRepeatStrategy, IView, VirtualizationCalculation, IScrollerInfo
 
 export class NullVirtualRepeatStrategy extends NullRepeatStrategy implements IVirtualRepeatStrategy {
 
+  // a violation of base contract, won't work in strict mode
+  // todo: fix this API design
+  createFirstRow(): IView | null {
+    return null;
+  }
+
+  count(items: any) {
+    return 0;
+  }
+
   getViewRange(repeat: VirtualRepeat, scrollerInfo: IScrollerInfo): [number, number] {
     return [0, 0];
   }
@@ -28,12 +38,6 @@ export class NullVirtualRepeatStrategy extends NullRepeatStrategy implements IVi
     // null/undefined virtual repeat strategy does not require any calculation
     // returning has_sizing to signal that
     return VirtualizationCalculation.has_sizing;
-  }
-
-  // a violation of base contract, won't work in strict mode
-  // todo: fix this API design
-  createFirstRow(): IView | null {
-    return null;
   }
 
   instanceMutated() {/*empty*/}

--- a/src/template-strategy-default.ts
+++ b/src/template-strategy-default.ts
@@ -25,7 +25,7 @@ export class DefaultTemplateStrategy implements ITemplateStrategy {
     const parent = element.parentNode;
     return [
       parent.insertBefore(DOM.createElement('div'), element),
-      parent.insertBefore(DOM.createElement('div'), element.nextSibling)
+      parent.insertBefore(DOM.createElement('div'), element.nextSibling),
     ];
   }
 

--- a/src/template-strategy-list.ts
+++ b/src/template-strategy-list.ts
@@ -38,7 +38,7 @@ export class ListTemplateStrategy extends DefaultTemplateStrategy implements ITe
     const parent = element.parentNode;
     return [
       parent.insertBefore(DOM.createElement('li'), element),
-      parent.insertBefore(DOM.createElement('li'), element.nextSibling)
+      parent.insertBefore(DOM.createElement('li'), element.nextSibling),
     ];
   }
 }

--- a/src/template-strategy-table.ts
+++ b/src/template-strategy-table.ts
@@ -17,7 +17,7 @@ abstract class BaseTableTemplateStrategy extends DefaultTemplateStrategy impleme
       // append tbody with empty row before the element
       parent.insertBefore(DOM.createElement('tr'), element),
       // append tbody with empty row after the element
-      parent.insertBefore(DOM.createElement('tr'), element.nextSibling)
+      parent.insertBefore(DOM.createElement('tr'), element.nextSibling),
     ];
   }
 

--- a/src/utilities-dom.ts
+++ b/src/utilities-dom.ts
@@ -1,6 +1,6 @@
 import { Math$round, $isNaN } from './utilities';
 import { IView } from './interfaces';
-import { htmlElement } from './constants';
+import { htmlElement, doc } from './constants';
 
 /**
  * Walk up the DOM tree and determine what element will be scroller for an element
@@ -15,7 +15,7 @@ export const getScrollerElement = (element: Node): HTMLElement => {
     }
     current = current.parentNode as HTMLElement;
   }
-  return htmlElement;
+  return doc.scrollingElement as HTMLElement || htmlElement;
 };
 
 /**

--- a/src/virtual-repeat.ts
+++ b/src/virtual-repeat.ts
@@ -724,8 +724,10 @@ export class VirtualRepeat extends AbstractRepeater implements IVirtualRepeater 
     // check if infinite scrollnext should be invoked
     // the following block cannot be nested inside didMoveViews condition
     // since there could be jumpy scrolling behavior causing infinite scrollnext
+    const all_items_in_range = this.items.length <= this.minViewsRequired * 2;
+    const state_to_check = all_items_in_range ? ScrollingState.isNearBottom : (ScrollingState.isNearBottom | ScrollingState.isScrollingDown);
     if (
-      (scrolling_state & (ScrollingState.isScrollingDown | ScrollingState.isNearBottom)) === (ScrollingState.isScrollingDown | ScrollingState.isNearBottom)
+      (scrolling_state & state_to_check) === state_to_check
       || (scrolling_state & (ScrollingState.isScrollingUp | ScrollingState.isNearTop)) === (ScrollingState.isScrollingUp | ScrollingState.isNearTop)
     ) {
       this.getMore(

--- a/src/virtual-repeat.ts
+++ b/src/virtual-repeat.ts
@@ -730,13 +730,14 @@ export class VirtualRepeat extends AbstractRepeater implements IVirtualRepeater 
     // check if infinite scrollnext should be invoked
     // the following block cannot be nested inside didMoveViews condition
     // since there could be jumpy scrolling behavior causing infinite scrollnext
-    const all_items_in_range = this.items.length <= this.minViewsRequired * 2;
     if (
       (scrolling_state & ScrollingState.isScrollingDownAndNearBottom) === ScrollingState.isScrollingDownAndNearBottom
       || (scrolling_state & ScrollingState.isScrollingUpAndNearTop) === ScrollingState.isScrollingUpAndNearTop
-      || all_items_in_range
-        // when all items in range, and somehow scroll handle is trigger
-        // but the scroll direction couldn't be derived from the view index (scroll too little etc...)
+      // Are all items in range?
+      // when all items are in range, and somehow scroll handle is triggered
+      // but the scroll direction couldn't be derived from the view index
+      //    (forcefully calling _handleScroll, scrolled too little, browser bug, touchpad sensitivity issues etc...)
+      || strategy.count(items) <= this.minViewsRequired * 2
         // then do check further to see if it's appropriate to load more
         // via either:
         // all items in range + not scrolling up + is near bottom

--- a/test/component-tester.ts
+++ b/test/component-tester.ts
@@ -4,7 +4,7 @@ import { Aurelia } from 'aurelia-framework';
 export const StageComponent = {
   withResources(resources): ComponentTester {
     return new ComponentTester().withResources(resources);
-  }
+  },
 };
 
 export class ComponentTester {

--- a/test/utilities.spec.tsx
+++ b/test/utilities.spec.tsx
@@ -16,7 +16,7 @@ describe('utiltites - DOM', () => {
         </div>,
       spaceAssertions: [
         ['#child', '#parent', 500],
-        ['#topBuffer', '#parent', 0]
+        ['#topBuffer', '#parent', 0],
       ],
       assert: (ct) => {
         const parent = ct.querySelector('#parent') as HTMLElement;
@@ -26,7 +26,7 @@ describe('utiltites - DOM', () => {
         expect(getDistanceToParent(child, parent)).toEqual(1);
         ct.style.marginTop = '-50px';
         expect(getDistanceToParent(child, parent)).toEqual(1);
-      }
+      },
     },
     {
       title: 'container with scrolling + buffer + child',
@@ -36,7 +36,7 @@ describe('utiltites - DOM', () => {
           <div id='child'></div>
         </div>,
       spaceAssertions: [
-        ['#child', '#parent', 500]
+        ['#child', '#parent', 500],
       ],
       assert: ct => {
         const parent = ct.querySelector('#parent') as HTMLElement;
@@ -48,7 +48,7 @@ describe('utiltites - DOM', () => {
         expect(getDistanceToParent(child, parent)).toEqual(1);
         topBuffer.insertAdjacentElement('afterend', <div style='height: 500px'></div>);
         expect(getDistanceToParent(child, parent)).toEqual(501);
-      }
+      },
     },
     {
       title: 'parent[relative + scrolling] + buffer + child',
@@ -60,8 +60,8 @@ describe('utiltites - DOM', () => {
         </div>,
       spaceAssertions: [
         ['#child', '#parent', 700],
-        ['#topBuffer', '#parent', 300]
-      ]
+        ['#topBuffer', '#parent', 300],
+      ],
     },
     {
       title: 'scroller > table > row',
@@ -77,13 +77,13 @@ describe('utiltites - DOM', () => {
         </div>,
       spaceAssertions: [
         ['#child', '#parent', 1000],
-        ['#topBuffer', '#parent', 400]
+        ['#topBuffer', '#parent', 400],
       ],
       assert: ct => {
         ct.scrollTop = 600;
         assertDistance(ct, '#child', '#parent', 1000);
         assertDistance(ct, '#topBuffer', '#parent', 400);
-      }
+      },
     },
     {
       title: 'scroller > div[relative] > div > table > row',
@@ -103,13 +103,13 @@ describe('utiltites - DOM', () => {
         </div>,
       spaceAssertions: [
         ['#child', '#parent', 1000],
-        ['#topBuffer', '#parent', 400]
+        ['#topBuffer', '#parent', 400],
       ],
       assert: ct => {
         ct.scrollTop = 800;
         assertDistance(ct, '#child', '#parent', 1000);
         assertDistance(ct, '#topBuffer', '#parent', 400);
-      }
+      },
     },
     {
       title: 'scroller > #shadow-root > div',
@@ -135,14 +135,14 @@ describe('utiltites - DOM', () => {
         parent.scrollTop = 200;
         assertDistance(ct, child, parent, 400);
         assertDistance(ct, topBuffer, parent, 0);
-      }
+      },
     },
     {
       title: [
         'container',
         '\t-- table [border-spacing:0]',
         '\t-- --> buffer',
-        '\t-- --> row'
+        '\t-- --> row',
       ].join('\n'),
       template:
         <div id='parent'>
@@ -173,8 +173,8 @@ describe('utiltites - DOM', () => {
         assertDistance(ct, child, parent, 500 + 400);
         assertDistance(ct, topBuffer, parent, 0 + 400);
         assertDistance(ct, cell, parent, 500 + 400);
-      }
-    }
+      },
+    },
   ];
 
   interface ITestCase {

--- a/test/value-converters.ts
+++ b/test/value-converters.ts
@@ -1,7 +1,7 @@
 export class IdentityValueConverter {
   static $resource = {
     type: 'valueConverter',
-    name: 'identity'
+    name: 'identity',
   };
   toView(val: any[]) {
     return val;
@@ -11,7 +11,7 @@ export class IdentityValueConverter {
 export class CloneArrayValueConverter {
   static $resource = {
     type: 'valueConverter',
-    name: 'cloneArray'
+    name: 'cloneArray',
   };
   toView(val: any[]) {
     return Array.isArray(val) ? val.slice() : val;

--- a/test/virtual-repeat-integration.spec.ts
+++ b/test/virtual-repeat-integration.spec.ts
@@ -162,7 +162,7 @@ describe('vr-integration.spec.ts', () => {
       create = Promise.all([
         create,
         hiddenCreate,
-        containerCreate
+        containerCreate,
       ]);
     });
 

--- a/test/virtual-repeat-integration.table.spec.ts
+++ b/test/virtual-repeat-integration.table.spec.ts
@@ -26,7 +26,7 @@ describe('vr-integration.table.spec.ts', () => {
     viewModel = { items: items };
     resources = [
       'src/virtual-repeat',
-      'test/noop-value-converter'
+      'test/noop-value-converter',
     ];
   });
 

--- a/test/vr-integration.infinite-scroll.spec.ts
+++ b/test/vr-integration.infinite-scroll.spec.ts
@@ -15,12 +15,12 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
   const resources = [
     'src/virtual-repeat',
     'src/infinite-scroll-next',
-    'test/noop-value-converter'
+    'test/noop-value-converter',
   ];
   class IdentityValueConverter {
     static $resource = {
       type: 'valueConverter',
-      name: 'identity'
+      name: 'identity',
     };
     toView(val: any[]) {
       return val;
@@ -29,7 +29,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
   class CloneArrayValueConverter {
     static $resource = {
       type: 'valueConverter',
-      name: 'cloneArray'
+      name: 'cloneArray',
     };
     toView(val: any[]) {
       return Array.isArray(val) ? val.slice() : val;
@@ -66,7 +66,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
             virtual-repeat.for="item of items ${repeatExpression}"
             ${scrollNextAttr}
             style="height: ${itemHeight}px;">\${item}</div>
-        </div>`
+        </div>`,
     },
     {
       desc: 'ul > li',
@@ -78,7 +78,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
             virtual-repeat.for="item of items ${repeatExpression}"
             ${scrollNextAttr}
             style="height: ${itemHeight}px;">\${item}</li>
-        </ul>`
+        </ul>`,
     },
     {
       desc: 'ol > li',
@@ -90,7 +90,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
             virtual-repeat.for="item of items ${repeatExpression}"
             ${scrollnextAttr}
             style="height: ${itemHeight}px;">\${item}</li>
-        </ol>`
+        </ol>`,
     },
     {
       desc: 'div > table > tr',
@@ -106,7 +106,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
               style="height: ${itemHeight}px;"><td>\${item}</td></tr>
           </table>
         </div>`;
-      }
+      },
     },
     {
       desc: 'div > table > tbody',
@@ -126,8 +126,8 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
             </tbody>
           </table>
         </div>`;
-      }
-    }
+      },
+    },
   ];
 
   const repeatScrollNextCombos: IRepeatScrollNextCombo[] = [
@@ -140,7 +140,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
     [' | cloneArray', 'infinite-scroll-next.call="getNextPage($scrollContext)"', [CloneArrayValueConverter]],
     [' | identity | cloneArray & toView', 'infinite-scroll-next="getNextPage"', [IdentityValueConverter, CloneArrayValueConverter]],
     [' | identity | cloneArray & toView', 'infinite-scroll-next.call="getNextPage($scrollContext)"', [IdentityValueConverter, CloneArrayValueConverter]],
-    [' | cloneArray & toView', 'infinite-scroll-next="getNextPage"', [CloneArrayValueConverter]]
+    [' | cloneArray & toView', 'infinite-scroll-next="getNextPage"', [CloneArrayValueConverter]],
 
     // cloneArray and two way creates infinite loop
     // [' | cloneArray & twoWay', 'infinite-scroll-next="getNextPage"', [CloneArrayValueConverter]]
@@ -172,7 +172,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       'Initial 3 - 4 - 5 - 6 items',
       ' -- wait',
       ' -- assert get more',
-      ''
+      '',
     ].join('\n\t'), async () => {
       let scrollNextArgs: [number, boolean, boolean];
       const spy = jasmine.createSpy('viewModel.getNextPage(): void', function(this: ITestAppInterface<string>, ...args: any[]) {
@@ -186,7 +186,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       let { component, virtualRepeat, viewModel } = await bootstrapComponent(
         {
           items: createItems(3),
-          getNextPage: spy
+          getNextPage: spy,
         },
         extraResources,
         $view
@@ -211,7 +211,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       ({ component, virtualRepeat, viewModel } = await bootstrapComponent(
         {
           items: createItems(4),
-          getNextPage: spy
+          getNextPage: spy,
         },
         extraResources,
         $view
@@ -233,7 +233,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       ({ component, virtualRepeat, viewModel } = await bootstrapComponent(
         {
           items: createItems(5),
-          getNextPage: spy
+          getNextPage: spy,
         },
         extraResources,
         $view
@@ -255,7 +255,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       ({ component, virtualRepeat, viewModel } = await bootstrapComponent(
         {
           items: createItems(6),
-          getNextPage: spy
+          getNextPage: spy,
         },
         extraResources,
         $view
@@ -278,7 +278,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       ' -- scroll down + get 100 more',
       ' -- wait',
       ' -- scroll up + get 100 more',
-      ''
+      '',
     ].join('\n\t'), async () => {
       const spy = jasmine.createSpy('viewModel.getNextPage(): void', function(this: ITestAppInterface<string>) {
         let itemLength = this.items.length;
@@ -290,7 +290,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent(
         {
           items: createItems(100),
-          getNextPage: spy
+          getNextPage: spy,
         },
         extraResources,
         $view
@@ -336,7 +336,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       ' -- jump to end',
       ' -- wait and assert',
       ' -- jump to start',
-      ' -- wait and assert'
+      ' -- wait and assert',
     ].join('\n\t'), async () => {
       let scrollNextArgs: [number, /*is near bottom*/boolean, /*is near top*/boolean];
       const spy = jasmine.createSpy('viewModel.getNextPage(): void', function(this: ITestAppInterface<string>, ...args: any[]) {
@@ -352,7 +352,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent(
         {
           items: createItems(100),
-          getNextPage: spy
+          getNextPage: spy,
         },
         extraResources,
         $view
@@ -412,7 +412,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       ' -- scroll down 20',
       ' -- wait and assert',
       ' -- scroll up',
-      ' -- wait and assert'
+      ' -- wait and assert',
     ].join('\n\t'), async () => {
       let scrollNextArgs: [number, /*is near bottom*/boolean, /*is near top*/boolean];
       const spy = jasmine.createSpy('viewModel.getNextPage(): void', function(this: ITestAppInterface<string>, ...args: any[]) {
@@ -428,7 +428,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent(
         {
           items: createItems(100),
-          getNextPage: spy
+          getNextPage: spy,
         },
         extraResources,
         $view
@@ -491,7 +491,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       'handles getting next data set with promises',
       ' -- sroll to end',
       ' -- wait',
-      ' -- scroll to top'
+      ' -- scroll to top',
     ].join('\n\t'), async () => {
       let scrollNextArgs: [number, boolean, boolean];
       let currentPromise: Promise<any>;
@@ -510,7 +510,7 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       let { component, virtualRepeat, viewModel } = await bootstrapComponent(
         {
           items: createItems(100),
-          getNextPage: spy
+          getNextPage: spy,
         },
         extraResources,
         $view
@@ -538,13 +538,84 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
       // loaded
       expect(viewModel.items.length).toBe(200, 'items.length 2 | promise resolved, loaded');
     });
+
+    it([
+      title,
+      'handles getting next data set with promises',
+      ' -- start 10 (smaller than min views required: 12)',
+      ' -- sroll 1px (no change in indices)',
+    ].join('\n\t'), async () => {
+      let scrollNextArgs: [number, boolean, boolean];
+      let currentPromise: Promise<any>;
+      const spy = jasmine.createSpy('viewModel.getNextPage(): void', function(this: ITestAppInterface<string>, ...args: any[]) {
+        let [_, isAtBottom] = scrollNextArgs = normalizeScrollNextArgs(args);
+        return new Promise(async (resolve) => {
+          await waitForFrames(2);
+          let itemLength = this.items.length;
+          for (let i = 0; i < 1; ++i) {
+            let itemNum = itemLength + i;
+            this.items.push('item' + itemNum);
+          }
+          resolve();
+        });
+      }).and.callThrough();
+      let { component, virtualRepeat, viewModel } = await bootstrapComponent(
+        {
+          items: createItems(10),
+          getNextPage: spy,
+        },
+        extraResources,
+        $view
+      );
+
+      expect(scrollNextArgs).toBe(undefined, 'getNextPage() args[]');
+      expect(virtualRepeat.minViewsRequired * 2).toBe(12, 'repeat._viewsLength');
+      expect(virtualRepeat.viewCount()).toBe(10, 'repeat.viewCount()');
+      expect(spy.calls.count()).toBe(0, 'no getNextPage() calls 1');
+
+      expect(viewModel.items.length).toBe(10, 'items.length 1');
+      validateScrolledState(virtualRepeat, viewModel, itemHeight);
+
+      scrollRepeat(virtualRepeat, 1);
+      // assert that nothing changed after
+      // 1 frame for scroll handler to start working
+      // 1 frame for getMore to be invoked
+      await waitForFrames(2);
+      assertScrollNextArgsEqual(scrollNextArgs, [0, true, true], 'scrollnextArgs 1');
+      // expect(scrollNextArgs).toEqual([/* first view index */0, true, false], 'scrollNextArgs 1');
+      expect(spy.calls.count()).toBe(1, '1 getNextPage() calls 2');
+
+      // not yet loaded
+      expect(viewModel.items.length).toBe(10, 'items.length 2 | promise started, not loaded');
+      await waitForFrames(2);
+      // loaded
+      expect(viewModel.items.length).toBe(11, 'items.length 2 | promise resolved, loaded');
+      validateScrolledState(virtualRepeat, viewModel, itemHeight);
+
+      // ========================
+      // try to scroll again, but back to 0 from 1px
+      scrollRepeat(virtualRepeat, 0);
+      // assert that nothing changed after
+      // 1 frame for scroll handler to start working
+      // 1 frame for getMore to be invoked
+      await waitForFrames(2);
+      assertScrollNextArgsEqual(scrollNextArgs, [0, true, true], 'scrollnextArgs 2');
+      expect(spy.calls.count()).toBe(2, '2 getNextPage() calls 3');
+
+      // not yet loaded
+      expect(viewModel.items.length).toBe(11, 'items.length 3 | promise started, not loaded');
+      await waitForFrames(2);
+      // loaded
+      expect(viewModel.items.length).toBe(12, 'items.length 3 | promise resolved, loaded');
+
+    });
   }
 
   async function bootstrapComponent<T>($viewModel?: ITestAppInterface<T>, extraResources?: any[], $view = view) {
     component = StageComponent
       .withResources([
         ...resources,
-        ...extraResources
+        ...extraResources,
       ])
       .inView($view)
       .boundTo($viewModel);
@@ -561,5 +632,14 @@ describe('vr-integration.infinite-scroll.spec.ts', () => {
     return typeof args[0] === 'number'
       ? [args[0], args[1], args[2]]
       : [args[0].topIndex, args[0].isAtBottom, args[0].isAtTop];
+  }
+
+  function assertScrollNextArgsEqual(scrollnextInfo: [number, boolean, boolean], expectedScrollnextInfo: [number, boolean, boolean], prefixMessage = ''): void {
+    expect(Array.isArray(scrollnextInfo)).toBe(true, `[${prefixMessage}] scroll next info should have been defined`);
+    const [actualTopIndex, actualIsNearBottom, actualIsNearTop] = scrollnextInfo;
+    const [expectedTopIndex, expectedIsNearBottom, expectedIsNearTop] = expectedScrollnextInfo;
+    expect(actualTopIndex).toBe(expectedTopIndex, `[${prefixMessage}] {top index(${actualTopIndex})} to be ${expectedTopIndex}`);
+    expect(actualIsNearBottom).toBe(expectedIsNearBottom, `[${prefixMessage}] {is near bottom(${actualIsNearBottom})} to be ${expectedIsNearBottom}`);
+    expect(actualIsNearTop).toBe(expectedIsNearTop, `[${prefixMessage}] {is near top (${actualIsNearTop})} to be ${expectedIsNearTop}`);
   }
 });

--- a/test/vr-integration.instance-changed.spec.ts
+++ b/test/vr-integration.instance-changed.spec.ts
@@ -23,7 +23,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
     // viewModel = { items: items };
     resources = [
       'src/virtual-repeat',
-      'test/noop-value-converter'
+      'test/noop-value-converter',
     ];
   });
 
@@ -110,7 +110,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
     it([
       'renders with 100 items',
       '  -- reduces to 30',
-      '  -- greater than (repeat._viewsLength)'
+      '  -- greater than (repeat._viewsLength)',
     ].join('\n\t'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
@@ -172,7 +172,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       'renders with 100 items',
       '  -- reduces to 16',
       '  -- lesser than (repeat._viewsLength)',
-      '  -- greater than (repeat.elementsInView)'
+      '  -- greater than (repeat.elementsInView)',
     ].join('\n\t'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
@@ -233,7 +233,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
     it([
       'renders with 100 items',
       '  -- reduces to 8',
-      '  -- lesser than (repeat.elementsInView)'
+      '  -- lesser than (repeat.elementsInView)',
     ].join('\n\t'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
@@ -298,7 +298,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       'renders with 100 items',
       '  -- reduces to 8',
       '  -- lesser than (repeat.elementsInView)',
-      '  -- increase to 30'
+      '  -- increase to 30',
     ].join('\n\t'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
@@ -350,7 +350,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       'renders with 100 items',
       '  -- reduces to 11',
       '  -- equal to (repeat.elementsInView)',
-      '  -- increase to 30'
+      '  -- increase to 30',
     ].join('\n\t'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
@@ -411,7 +411,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
 
     it([
       'tbody[repeat]',
-      'renders with 100 items'
+      'renders with 100 items',
     ].join('\n\t'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
@@ -463,7 +463,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       'tbody[repeat]',
       'renders with 100 items',
       '  -- reduces to 30',
-      '  -- greater than (repeat._viewsLength)'
+      '  -- greater than (repeat._viewsLength)',
     ].join('\n\t'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
@@ -524,7 +524,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       '  -- greater than (repeat._viewsLength)',
       '  -- reduces to null',
       '  -- increase to 50',
-      '  -- reduces to undefined'
+      '  -- reduces to undefined',
     ].join('\n\t'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
@@ -604,7 +604,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       'renders with 100 items',
       '  -- reduces to 16',
       '  -- lesser than (repeat._viewsLength)',
-      '  -- greater than (repeat.elementsInView)'
+      '  -- greater than (repeat.elementsInView)',
     ].join('\n\t'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
@@ -662,7 +662,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       'tbody[repeat]',
       'renders with 100 items',
       '  -- reduces to 8',
-      '  -- lesser than (repeat.elementsInView)'
+      '  -- lesser than (repeat.elementsInView)',
     ].join('\n\t'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
@@ -730,7 +730,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       'renders with 100 items',
       '  -- reduces to 11',
       '  -- equal to (repeat.elementsInView)',
-      '  -- increase to 30'
+      '  -- increase to 30',
     ].join('\n\t'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
@@ -833,7 +833,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
     it([
       'renders with 100 items',
       '  -- reduces to 30',
-      '  -- greater than (repeat._viewsLength)'
+      '  -- greater than (repeat._viewsLength)',
     ].join('\n\t'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
@@ -889,7 +889,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       'renders with 100 items',
       '  -- reduces to 16',
       '  -- lesser than (repeat._viewsLength)',
-      '  -- greater than (repeat.elementsInView)'
+      '  -- greater than (repeat.elementsInView)',
     ].join('\n\t'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
@@ -944,7 +944,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
     it([
       'renders with 100 items',
       '  -- reduces to 8',
-      '  -- lesser than (repeat.elementsInView)'
+      '  -- lesser than (repeat.elementsInView)',
     ].join('\n\t'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
@@ -1009,7 +1009,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
       'renders with 100 items',
       '  -- reduces to 11',
       '  -- equal to (repeat.elementsInView)',
-      '  -- increase to 30'
+      '  -- increase to 30',
     ].join('\n\t'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
 
@@ -1079,7 +1079,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
     function runTestSuit(title: string, $view: string) {
       it([
         title,
-        'renders with 100 items'
+        'renders with 100 items',
       ].join('\n\t'), async () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
@@ -1136,7 +1136,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         title,
         'renders with 100 items',
         '  -- reduces to 30',
-        '  -- greater than (repeat._viewsLength)'
+        '  -- greater than (repeat._viewsLength)',
       ].join('\n\t'), async () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
@@ -1199,7 +1199,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         '  -- greater than (repeat._viewsLength)',
         '  -- reduces to null',
         '  -- increase to 50',
-        '  -- reduces to undefined'
+        '  -- reduces to undefined',
       ].join('\n\t'), async () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
@@ -1279,7 +1279,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         'renders with 100 items',
         '  -- reduces to 16',
         '  -- lesser than (repeat._viewsLength)',
-        '  -- greater than (repeat.elementsInView)'
+        '  -- greater than (repeat.elementsInView)',
       ].join('\n\t'), async () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
@@ -1337,7 +1337,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         title,
         'renders with 100 items',
         '  -- reduces to 8',
-        '  -- lesser than (repeat.elementsInView)'
+        '  -- lesser than (repeat.elementsInView)',
       ].join('\n\t'), async () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
@@ -1406,7 +1406,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         'renders with 100 items',
         '  -- reduces to 11',
         '  -- equal to (repeat.elementsInView)',
-        '  -- increase to 30'
+        '  -- increase to 30',
       ].join('\n\t'), async () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
@@ -1479,7 +1479,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
     function runTestSuit(title: string, $view: string) {
       it([
         title,
-        'renders with 100 items'
+        'renders with 100 items',
       ].join('\n\t'), async () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
@@ -1541,7 +1541,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         '  -- greater than (repeat._viewsLength)',
         '  -- reduces to null',
         '  -- increase to 50',
-        '  -- reduces to undefined'
+        '  -- reduces to undefined',
       ].join('\n\t'), async () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
@@ -1622,7 +1622,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         title,
         'renders with 100 items',
         '  -- reduces to 30',
-        '  -- greater than (repeat._viewsLength)'
+        '  -- greater than (repeat._viewsLength)',
       ].join('\n\t'), async () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
@@ -1685,7 +1685,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         'renders with 100 items',
         '  -- reduces to 16',
         '  -- lesser than (repeat._viewsLength)',
-        '  -- greater than (repeat.elementsInView)'
+        '  -- greater than (repeat.elementsInView)',
       ].join('\n\t'), async () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 
@@ -1741,7 +1741,7 @@ describe('vr-integration.instance-changed.spec.ts', () => {
         title,
         'renders with 100 items',
         '  -- reduces to 8',
-        '  -- lesser than (repeat.elementsInView)'
+        '  -- lesser than (repeat.elementsInView)',
       ].join('\n\t'), async () => {
         const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items }, $view);
 

--- a/test/vr-integration.instance-mutated.spec.ts
+++ b/test/vr-integration.instance-mutated.spec.ts
@@ -21,7 +21,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
     items = createItems(1000);
     resources = [
       'src/virtual-repeat',
-      'test/noop-value-converter'
+      'test/noop-value-converter',
     ];
   });
 
@@ -52,12 +52,12 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       class {
         static $resource = {
           type: 'valueConverter',
-          name: 'identity'
+          name: 'identity',
         };
         toView(val: any[]) {
           return val;
         }
-      }
+      },
     ]
   );
 
@@ -70,12 +70,12 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       class {
         static $resource = {
           type: 'valueConverter',
-          name: 'cloneArray'
+          name: 'cloneArray',
         };
         toView(val: any[]) {
           return Array.isArray(val) ? val.slice() : val;
         }
-      }
+      },
     ]
   );
 
@@ -88,7 +88,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       class {
         static $resource = {
           type: 'valueConverter',
-          name: 'identity'
+          name: 'identity',
         };
         toView(val: any[]) {
           return val;
@@ -97,12 +97,12 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       class {
         static $resource = {
           type: 'valueConverter',
-          name: 'cloneArray'
+          name: 'cloneArray',
         };
         toView(val: any[]) {
           return Array.isArray(val) ? val.slice() : val;
         }
-      }
+      },
     ]
   );
 
@@ -129,7 +129,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       class {
         static $resource = {
           type: 'valueConverter',
-          name: 'identity'
+          name: 'identity',
         };
         toView(val: any[]) {
           return val;
@@ -138,12 +138,12 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       class {
         static $resource = {
           type: 'valueConverter',
-          name: 'cloneArray'
+          name: 'cloneArray',
         };
         toView(val: any[]) {
           return Array.isArray(val) ? val.slice() : val;
         }
-      }
+      },
     ]
   );
 
@@ -151,7 +151,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
     it([
       title,
       '\thandles splice when scrolled to end',
-      ''
+      '',
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
@@ -168,7 +168,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
     it([
       title,
       '\thandles splice removing non-consecutive when scrolled to end',
-      ''
+      '',
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({
         items: items,
@@ -178,7 +178,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
             let itemNum = itemLength + i;
             this.items.push('item' + itemNum);
           }
-        }
+        },
       });
       await scrollToEnd(virtualRepeat);
 
@@ -200,7 +200,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       '\t1000 items',
       '\t-- 12 max views',
       '\t-- splice to 840 (every 10 increment, remove 3 add i, 80 times)',
-      ''
+      '',
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
@@ -227,7 +227,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       '\t1000 items',
       '\t-- 12 max views',
       '\t-- splice to 24',
-      ''
+      '',
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
@@ -247,7 +247,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
     it([
       title,
       '\thandles splice removing more',
-      ''
+      '',
     ].join('\n'), async () => {
       // number of items remaining exactly as viewslot capacity
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
@@ -265,7 +265,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
     it([
       title,
       '\thandles splice removing even more',
-      ''
+      '',
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
@@ -281,7 +281,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
     it([
       title,
       '\thandles splice removing non-consecutive',
-      ''
+      '',
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
@@ -297,7 +297,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
     it([
       title,
       '\thandles splice non-consecutive',
-      ''
+      '',
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
@@ -316,7 +316,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       '\t-- 1000 items',
       '\t-- 12 max views',
       '\t-- spliced to 12',
-      ''
+      '',
     ].join('\n'), async () => {
       let scrollCount = 0;
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
@@ -364,7 +364,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       '\t1000 items',
       '\t-- 12 max views',
       '\t-- spliced to 13',
-      ''
+      '',
     ].join('\n'), async () => {
       let scrollCount = 0;
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
@@ -394,7 +394,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
         expect(virtualRepeat.items.length).toBe(13, 'items.length 1');
         expect(virtualRepeat.element.parentElement.scrollTop).toBe(100 * 995);
 
-        await waitForNextFrame();
+        await waitForFrames(2);
         expect(scrollCount).toBe(3, '@scroll 3');
         validateScrolledState(virtualRepeat, viewModel, itemHeight);
       }
@@ -404,7 +404,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
     it([
       title,
       '\thandles splice remove remaining + add',
-      ''
+      '',
     ].join('\n'), async () => {
       const { virtualRepeat, viewModel } = await bootstrapComponent({ items: items });
       await scrollToEnd(virtualRepeat);
@@ -419,7 +419,7 @@ describe('vr-integration.instance-mutated.spec.ts', () => {
       component = StageComponent
         .withResources([
           ...resources,
-          ...extraResources
+          ...extraResources,
         ])
         .inView($view)
         .boundTo($viewModel);

--- a/test/vr-integration.resizing.spec.ts
+++ b/test/vr-integration.resizing.spec.ts
@@ -1,13 +1,12 @@
 import './setup';
 import { PLATFORM } from 'aurelia-pal';
-import { validateScrolledState, ensureScrolled, scrollToEnd, waitForNextFrame, validateState, waitForTimeout, waitForFrames } from './utilities';
+import { validateScrolledState, waitForFrames } from './utilities';
 import { VirtualRepeat } from '../src/virtual-repeat';
 import { StageComponent, ComponentTester } from 'aurelia-testing';
 import { bootstrap } from 'aurelia-bootstrapper';
 import { ITestAppInterface } from './interfaces';
-import { eachCartesianJoin, eachCartesianJoinAsync } from './lib';
+import { eachCartesianJoin } from './lib';
 import { ElementEvents } from 'aurelia-framework';
-import { getDistanceToParent } from '../src/utilities-dom';
 import { IdentityValueConverter, CloneArrayValueConverter } from './value-converters';
 
 PLATFORM.moduleName('src/virtual-repeat');

--- a/test/vr-integration.scrolling.spec.ts
+++ b/test/vr-integration.scrolling.spec.ts
@@ -28,7 +28,7 @@ describe('vr-integration.scrolling.spec.ts', () => {
     // viewModel = { items: items };
     resources = [
       'src/virtual-repeat',
-      'test/noop-value-converter'
+      'test/noop-value-converter',
     ];
   });
 
@@ -167,7 +167,7 @@ describe('vr-integration.scrolling.spec.ts', () => {
       '\t[body rows] <-- h:50 each',
       '\t[separator row] <-- h:100',
       '\t[body rows] <-- h:50 each',
-      '\t-- scrollTop from 0 to 79 should not affect first row'
+      '\t-- scrollTop from 0 to 79 should not affect first row',
     ].join('\n'), async () => {
       const { viewModel, virtualRepeat } = await bootstrapComponent({ items: createItems(100) }, view);
       const scrollCtEl = document.querySelector('#scrollCtEl');
@@ -214,7 +214,7 @@ describe('vr-integration.scrolling.spec.ts', () => {
     [' | cloneArray', 'infinite-scroll-next.call="getNextPage($scrollContext)"', [CloneArrayValueConverter]],
     [' | identity | cloneArray & toView', 'infinite-scroll-next="getNextPage"', [IdentityValueConverter, CloneArrayValueConverter]],
     [' | identity | cloneArray & toView', 'infinite-scroll-next.call="getNextPage($scrollContext)"', [IdentityValueConverter, CloneArrayValueConverter]],
-    [' | cloneArray & toView', 'infinite-scroll-next="getNextPage"', [CloneArrayValueConverter]]
+    [' | cloneArray & toView', 'infinite-scroll-next="getNextPage"', [CloneArrayValueConverter]],
 
     // cloneArray and two way creates infinite loop
     // [' | cloneArray & twoWay', 'infinite-scroll-next="getNextPage"', [CloneArrayValueConverter]]
@@ -231,7 +231,7 @@ describe('vr-integration.scrolling.spec.ts', () => {
           '-- 100 items',
           `-- [theader row] <-- h:${topBufferOffset}`,
           `-- [tr rows] <-- h:${itemHeight} each`,
-          ''
+          '',
         ].join('\n\t'),
       createView: (itemHeight, scrollerHeight, topBufferOffset, repeatAttr) =>
         `<div style="height: ${scrollerHeight}px; overflow-y: auto">
@@ -247,7 +247,7 @@ describe('vr-integration.scrolling.spec.ts', () => {
               <td>\${item}</td>
             </tr>
           </table>
-        </div>`
+        </div>`,
     },
     {
       topBufferOffset: 30,
@@ -259,7 +259,7 @@ describe('vr-integration.scrolling.spec.ts', () => {
           '-- 100 items',
           `-- [theader row] <-- h:${topBufferOffset}`,
           `-- [tbody rows] <-- h:${itemHeight} each`,
-          ''
+          '',
         ].join('\n\t'),
       createView: (itemHeight, scrollerHeight, topBufferOffset, repeatAttr) =>
         `<div style="height: ${scrollerHeight}px; overflow-y: auto">
@@ -277,7 +277,7 @@ describe('vr-integration.scrolling.spec.ts', () => {
               </tr>
             </tbody>
           </table>
-        </div>`
+        </div>`,
     },
     {
       topBufferOffset: 0,
@@ -288,7 +288,7 @@ describe('vr-integration.scrolling.spec.ts', () => {
           `div[scroller h:${scrollerHeight}] > ol > li[repeat${repeatAttr}]`,
           '-- 100 items',
           `-- [li rows] <-- h:${itemHeight} each`,
-          ''
+          '',
         ].join('\n\t'),
       createView: (itemHeight, scrollerHeight, topBufferOffset, repeatAttr) =>
         `<div style="height: ${scrollerHeight}px; overflow-y: auto">
@@ -297,7 +297,7 @@ describe('vr-integration.scrolling.spec.ts', () => {
               \${$index}
             </li>
           </ol>
-        </div>`
+        </div>`,
     },
     {
       topBufferOffset: 0,
@@ -308,15 +308,15 @@ describe('vr-integration.scrolling.spec.ts', () => {
           `ol[scroller h:${scrollerHeight}] > li[repeat${repeatAttr}]`,
           '-- 100 items',
           `-- [li rows] <-- h:${itemHeight} each`,
-          ''
+          '',
         ].join('\n\t'),
       createView: (itemHeight, scrollerHeight, topBufferOffset, repeatAttr) =>
         `<ol style="height: ${scrollerHeight}px; overflow-y: auto; list-style: none; margin: 0;">
           <li virtual-repeat.for="item of items ${repeatAttr}" style="height: ${itemHeight}px;">
             \${$index}
           </li>
-        </ol>`
-    }
+        </ol>`,
+    },
   ];
 
   eachCartesianJoin(
@@ -339,7 +339,7 @@ describe('vr-integration.scrolling.spec.ts', () => {
     {
       itemHeight,
       scrollerHeight,
-      topBufferOffset
+      topBufferOffset,
     }: {
       itemHeight: number;
       scrollerHeight: number;
@@ -351,7 +351,7 @@ describe('vr-integration.scrolling.spec.ts', () => {
     describe(title, () => {
       it([
         '100 items',
-        `-- scrollTop from 0 to ${itemHeight - 1} should not affect first row`
+        `-- scrollTop from 0 to ${itemHeight - 1} should not affect first row`,
       ].join('\n\t'), async () => {
         const ITEM_COUNT = 100;
         const { viewModel, virtualRepeat } = await bootstrapComponent(
@@ -378,7 +378,7 @@ describe('vr-integration.scrolling.spec.ts', () => {
       it([
         `100 items`,
         `-- scroll to bottom`,
-        `-- scroll from bottom to index ${100 - calcMinViewsRequired(scrollerHeight, itemHeight)} should not affect first row`
+        `-- scroll from bottom to index ${100 - calcMinViewsRequired(scrollerHeight, itemHeight)} should not affect first row`,
       ].join('\n\t'), async () => {
         const ITEM_COUNT = 100;
         const { viewModel, virtualRepeat } = await bootstrapComponent(

--- a/tslint.json
+++ b/tslint.json
@@ -69,7 +69,14 @@
       true,
       {
         "singleline": "never",
-        "multiline": "never"
+        "multiline": {
+          "arrays": "always",
+          "objects": "always",
+          "imports": "always",
+          "exports": "always",
+          "typeLiterals": "always",
+          "functions": "never"
+        }
       }
     ],
     "triple-equals": [


### PR DESCRIPTION
Superseded #173 

Currently when the amount of scroll is too little, it's considered a non-semantic scroll, which means no view has actually been shifted in/out of the scroller viewport yet. This results in situation where getMore for infinite scroll next may not be called. This PR fixes this.