### PR TITLE
Fix templateStrategy removeBuffers to check whether parent contains elements before removing

### DIFF
--- a/src/template-strategy-default.ts
+++ b/src/template-strategy-default.ts
@@ -31,8 +31,12 @@ export class DefaultTemplateStrategy implements ITemplateStrategy {
 
   removeBuffers(el: Element, topBuffer: Element, bottomBuffer: Element): void {
     const parent = el.parentNode;
-    parent.removeChild(topBuffer);
-    parent.removeChild(bottomBuffer);
+    if (parent.contains(topBuffer)) {
+      parent.removeChild(topBuffer);
+    }
+    if (parent.contains(bottomBuffer)) {
+      parent.removeChild(bottomBuffer);
+    }
   }
 
   getFirstElement(topBuffer: Element, bottomBuffer: Element): Element {


### PR DESCRIPTION
It's possible to run into an error where detaching the virtual repeat will lose context of the bottom and top buffer elements (due to underlying conditional changes possibly). As a result, the templateStrategy.removeBuffers will throw an error when you attempt to call removeChild when the element is not a child of the given parent element.